### PR TITLE
Dev/luke

### DIFF
--- a/dfttk/eos_fit.py
+++ b/dfttk/eos_fit.py
@@ -1202,11 +1202,24 @@ def plot_mv(df, show_fig=True):
     return fig
 
 
-def assign_colors_to_configs(df, alpha=1):
-    
+def assign_colors_to_configs(df, alpha=1, cmap='plotly'):
     unique_configs = df["config"].unique()
-    colors = get_colors(len(unique_configs))
-    colors = [f'rgba({color[0]}, {color[1]}, {color[2]}, {alpha})' for color in colors]
+
+    
+    if cmap == 'plotly':
+        colors = px.colors.qualitative.Plotly
+        colors = ['#636EFA', '#EF553B', '#00CC96',
+                  '#AB63FA', '#FFA15A', '#19D3F3',
+                  '#FF6692', '#B6E880', '#FF97FF',
+                  '#FECB52']
+        colors = [f'rgba({int(color[1:3], 16)}, {int(color[3:5], 16)}, {int(color[5:7], 16)}, {alpha})' for color in colors]
+        
+    elif cmap == 'distinctipy':
+        colors = get_colors(len(unique_configs))
+        colors = [f'rgba({color[0]}, {color[1]}, {color[2]}, {alpha})' for color in colors]
+    else:
+        print("cmap must be 'plotly' or 'distinctipy'")
+
     config_colors = {config: colors[i % len(colors)] for i, config in enumerate(unique_configs)}
     return config_colors
 
@@ -1235,6 +1248,7 @@ def plot_ev(
     show_fig=True,
     left_col="volume",
     right_col="energy",
+    cmap='plotly',
     marker_alpha=1
 ):
     # determine the type of data and how to handle it.
@@ -1258,7 +1272,7 @@ def plot_ev(
         eos_df = fit_to_all_eos(df)
 
     # assign colors and symbols
-    config_colors = assign_colors_to_configs(df, alpha=marker_alpha)
+    config_colors = assign_colors_to_configs(df, alpha=marker_alpha, cmap=cmap)
     config_symbols = assign_marker_symbols_to_configs(df)
         
     # plot the data
@@ -1492,7 +1506,8 @@ def plot_energy_difference(
     show_fig=True,
     convert_to_mev=False,
     title=None,
-    marker_alpha=1):
+    marker_alpha=1,
+    cmap='plotly'):
     """
     Takes a dataframe and plots the energy difference from a 
     reference configuration within the dataframe vs volume.
@@ -1528,6 +1543,7 @@ def plot_energy_difference(
                   eos_fitting=None,
                   per_atom=per_atom,
                   show_fig=False,
+                  cmap=cmap,
                   marker_alpha=marker_alpha)
     if convert_to_mev and not per_atom:
         fig.update_layout(yaxis_title=dict(text=r"$\Delta \text{E (meV)}$", font=dict(color='rgb(0,0,0)')))

--- a/dfttk/eos_fit.py
+++ b/dfttk/eos_fit.py
@@ -1508,7 +1508,8 @@ def plot_energy_difference(
     convert_to_mev=False,
     title=None,
     marker_alpha=1,
-    cmap='plotly'):
+    cmap='plotly',
+    marker_size=10):
     """
     Takes a dataframe and plots the energy difference from a 
     reference configuration within the dataframe vs volume.
@@ -1544,8 +1545,10 @@ def plot_energy_difference(
                   eos_fitting=None,
                   per_atom=per_atom,
                   show_fig=False,
+                  title=title,
                   cmap=cmap,
-                  marker_alpha=marker_alpha)
+                  marker_alpha=marker_alpha,
+                  marker_size=marker_size)
     if convert_to_mev and not per_atom:
         fig.update_layout(yaxis_title=dict(text=r"$\Delta \text{E (meV)}$", font=dict(color='rgb(0,0,0)')))
     elif not convert_to_mev and not per_atom:

--- a/dfttk/eos_fit.py
+++ b/dfttk/eos_fit.py
@@ -1249,7 +1249,8 @@ def plot_ev(
     left_col="volume",
     right_col="energy",
     cmap='plotly',
-    marker_alpha=1
+    marker_alpha=1,
+    marker_size=10
 ):
     # determine the type of data and how to handle it.
     if isinstance(data, pd.DataFrame):
@@ -1293,7 +1294,7 @@ def plot_ev(
                 y=y,
                 mode="markers",
                 marker=dict(
-                    size=10,
+                    size=marker_size,
                     color=config_colors[config],
                     symbol=config_symbols[config]
                 ),
@@ -1361,7 +1362,7 @@ def plot_ev(
                                 y=[min_energy],
                                 mode="markers",
                                 name=f"{eos_fitting} min energy",
-                                marker=dict(color="black", size=10, symbol="cross"),
+                                marker=dict(color="black", size=marker_size, symbol="cross"),
                                 legendgroup="minimum",
                                 showlegend=False
                             )
@@ -1379,7 +1380,7 @@ def plot_ev(
                                 ],
                                 mode="markers",
                                 name=f"{eos_fitting} min energy",
-                                marker=dict(color="black", size=10, symbol="cross"),
+                                marker=dict(color="black", size=marker_size, symbol="cross"),
                                 legendgroup="minimum",
                                 showlegend=False
                             )
@@ -1436,7 +1437,7 @@ def plot_ev(
                                     y=[min_energy],
                                     mode="markers",
                                     name=f"{eos_name} min energy",
-                                    marker=dict(color="black", size=8, symbol="cross"),
+                                    marker=dict(color="black", size=marker_size, symbol="cross"),
                                     legendgroup="minimum",
                                     showlegend=False
                             )
@@ -1454,7 +1455,7 @@ def plot_ev(
                                     ],
                                     mode="markers",
                                     name=f"{eos_name} min energy",
-                                    marker=dict(color="black", size=8, symbol="cross"),
+                                    marker=dict(color="black", size=marker_size, symbol="cross"),
                                     legendgroup="minimum",
                                     showlegend=False
                             )


### PR DESCRIPTION
Added cmap and marker_size options to plot_ev() and plot_energy_differce(). the diffault is plotly
```
plot_ev(
    data,
    eos_fitting="BM4",
    highlight_minimum=True,
    per_atom=False,
    title=None,
    show_fig=True,
    left_col="volume",
    right_col="energy",
    cmap='plotly',
    marker_alpha=1,
    marker_size=10
)
```

```
plot_energy_difference(
    df,
    reference_config,
    per_atom=False,
    show_fig=True,
    convert_to_mev=False,
    title=None,
    marker_alpha=1,
    cmap='plotly')
```