### PR TITLE
magnetic data update

### DIFF
--- a/dfttk/workflows.py
+++ b/dfttk/workflows.py
@@ -203,25 +203,27 @@ def extract_tot_mag_data(ion_list, outcar_path="OUTCAR"):
   
 #TODO:change path to a list of paths so that it can read multiple config folders automatically?
 def extract_configuration_data(
-    path,
-    ion_list=[1],
-    outcar_name="OUTCAR",
-    oszicar_name="OSZICAR",
-    contcar_name="CONTCAR",
-    collect_mag_data="False",
-    magmom_tolerance=0
+    path: list[str],
+    outcar_name: str ='OUTCAR.3static',
+    oszicar_name: str ='OSZICAR.3static',
+    contcar_name: str ='CONTCAR.3static', 
+    collect_mag_data: bool = False,
+    ion_list: list[int] = [1],
+    magmom_tolerance: float = 0
 ):
     """Extracts the volume, configuration, energy, number of atoms, and magnetization data (if specified) from calculations 
     run by ev_curve_series and returns a pandas DataFrame.
 
     Args:
-        path (str): the path containing a config_* folder which contain vol_* folders
-        ion_list (list, optional): the list of ions for magnetization data. Defaults to [1].
-        outcar_name (str, optional): name of the OUTCAR file. Defaults to "OUTCAR".
-        oszicar_name (str, optional): name of the OSZICAR file. Defaults to "OSZICAR".
-        contcar_name (str, optional): name of the CONTCAR file. Defaults to "CONTCAR".
-        collect_mag_data (str, optional): if True, collect the magnetization data using extract_tot_mag_data.
-        Defaults to "False".
+        path: the path containing a config_* folder which contain vol_* folders
+        outcar_name: name of the OUTCAR file. Defaults to "OUTCAR".
+        oszicar_name: name of the OSZICAR file. Defaults to "OSZICAR".
+        contcar_name: name of the CONTCAR file. Defaults to "CONTCAR".
+        collect_mag_data: if True, collect the magnetization data using extract_tot_mag_data. Defaults to
+        False.
+        ion_list: specifies the ions to collect magnetization data for -- corresponds to '# of ion' in the
+        OUTCAR. Defaults to [1].
+        magmom_tolerance: the tolerance for the total magnetic moment to be considered zero. Defaults to 0.
 
     Returns:
         pandas DataFrame: a pandas DataFrame containing the volume, configuration, energy, number of atoms, and 
@@ -281,6 +283,44 @@ def extract_configuration_data(
     df = pd.DataFrame(row_list)
     return df
 
+
+def recursive_extract_configuration_data(
+    config_dirs: list[str],
+    outcar_name: str ='OUTCAR',
+    oszicar_name: str ='OSZICAR',
+    contcar_name: str ='CONTCAR', 
+    collect_mag_data: bool = False,
+    ion_list: list[int] = [1],
+    magmom_tolerance: float = 0
+    ):
+    """convenience function to extract configuration data from multiple config directories.
+    Runs extract_configuration_data for each config directory in a list.
+
+    Args:
+        config_dirs: list of paths to config directories that will be passed to extract_configuration_data()
+        outcar_name: name of the OUTCAR file. Defaults to "OUTCAR".
+        oszicar_name: name of the OSZICAR file. Defaults to "OSZICAR".
+        contcar_name: name of the CONTCAR file. Defaults to "CONTCAR".
+        collect_mag_data: if True, collect the magnetization data using extract_tot_mag_data. Defaults to
+        False.
+        ion_list: specifies the ions to collect magnetization data for -- corresponds to '# of ion' in the
+        OUTCAR. Defaults to [1].
+        magmom_tolerance: the tolerance for the total magnetic moment to be considered zero. Defaults to 0.
+        
+    """
+    df_list = []
+    for config_dir in config_dirs:
+        try:
+            config_df = extract_configuration_data(
+                config_dir, outcar_name=outcar_name, 
+                oszicar_name=oszicar_name, contcar_name=contcar_name, 
+                collect_mag_data=collect_mag_data)
+            df_list.append(config_df)
+        except Exception as e:
+            print(f'Error in {config_dir}: {e}')
+    df = pd.concat(df_list, ignore_index=True)
+    return df
+    
 
 def three_step_relaxation(
     path,

--- a/dfttk/workflows.py
+++ b/dfttk/workflows.py
@@ -257,15 +257,15 @@ def extract_configuration_data(
             total_magnetic_moment = mag_data['tot'].sum()
             
             if (mag_data['tot'] == 0).all():
-                magnetic_ordering = 'nonmagnetic'
+                magnetic_ordering = 'NM'
             elif np.isclose(total_magnetic_moment, 0,  atol=magmom_tolerance) == True:
-                magnetic_ordering = 'antiferromagnetic'
+                magnetic_ordering = 'AFM'
             elif (mag_data['tot'] >= 0).all() or (mag_data['tot'] <= 0).all():
-                magnetic_ordering = 'ferromagnetic'
+                magnetic_ordering = 'FM'
             elif (mag_data['tot'] > 0).sum() == (mag_data['tot'] < 0).sum():
-                magnetic_ordering = 'ferrimagnetic'
+                magnetic_ordering = 'FiM'
             else :
-                magnetic_ordering = 'spin-flipping'
+                magnetic_ordering = 'SF'
             
             row = {
                 "config": config,

--- a/dfttk/workflows.py
+++ b/dfttk/workflows.py
@@ -251,6 +251,8 @@ def extract_configuration_data(
         number_of_atoms = len(struct.sites)
         vol = extract_volume(contcar_path)
         energy = extract_energy(oszicar_path)
+        energy_per_atom = energy / number_of_atoms
+        vol_per_atom = vol / number_of_atoms
         if collect_mag_data == True:
             mag_data = extract_tot_mag_data(outcar_path)
             total_magnetic_moment = mag_data['tot'].sum()
@@ -260,9 +262,11 @@ def extract_configuration_data(
                 afm = False
             
             row = {
-                "volume": vol,
                 "config": config,
+                "volume": vol,
+                "volume/atom": vol_per_atom,
                 "energy": energy,
+                "energy/atom": energy_per_atom,
                 "number_of_atoms": number_of_atoms,
                 "total_magnetic_moment": total_magnetic_moment,
                 "afm": afm,
@@ -270,9 +274,11 @@ def extract_configuration_data(
             }
         else:
             row = {
-                "volume": vol,
                 "config": config,
+                "volume": vol,
+                "volume/atom": vol_per_atom,
                 "energy": energy,
+                "energy/atom": energy_per_atom,
                 "number_of_atoms": number_of_atoms,
             }
         row_list.append(row)

--- a/dfttk/workflows.py
+++ b/dfttk/workflows.py
@@ -199,7 +199,6 @@ def extract_tot_mag_data(outcar_path="OUTCAR"):
     return tot_data
 
   
-#TODO:change path to a list of paths so that it can read multiple config folders automatically?
 def extract_configuration_data(
     path: list[str],
     outcar_name: str ='OUTCAR.3static',
@@ -256,10 +255,17 @@ def extract_configuration_data(
         if collect_mag_data == True:
             mag_data = extract_tot_mag_data(outcar_path)
             total_magnetic_moment = mag_data['tot'].sum()
-            if np.isclose(total_magnetic_moment, 0,  atol=magmom_tolerance) == True:
-                afm = True
-            else:
-                afm = False
+            
+            if (mag_data['tot'] == 0).all():
+                magnetic_ordering = 'nonmagnetic'
+            elif np.isclose(total_magnetic_moment, 0,  atol=magmom_tolerance) == True:
+                magnetic_ordering = 'antiferromagnetic'
+            elif (mag_data['tot'] >= 0).all() or (mag_data['tot'] <= 0).all():
+                magnetic_ordering = 'ferromagnetic'
+            elif (mag_data['tot'] > 0).sum() == (mag_data['tot'] < 0).sum():
+                magnetic_ordering = 'ferrimagnetic'
+            else :
+                magnetic_ordering = 'spin-flipping'
             
             row = {
                 "config": config,
@@ -269,7 +275,7 @@ def extract_configuration_data(
                 "energy/atom": energy_per_atom,
                 "number_of_atoms": number_of_atoms,
                 "total_magnetic_moment": total_magnetic_moment,
-                "afm": afm,
+                "magnetic_ordering": magnetic_ordering,
                 "mag_data": mag_data
             }
         else:

--- a/dfttk/workflows.py
+++ b/dfttk/workflows.py
@@ -209,6 +209,7 @@ def extract_configuration_data(
     oszicar_name="OSZICAR",
     contcar_name="CONTCAR",
     collect_mag_data="False",
+    magmom_tolerance=0
 ):
     """Extracts the volume, configuration, energy, number of atoms, and magnetization data (if specified) from calculations 
     run by ev_curve_series and returns a pandas DataFrame.
@@ -254,12 +255,20 @@ def extract_configuration_data(
         energy = extract_energy(oszicar_path)
         if collect_mag_data == True:
             mag_data = extract_tot_mag_data(ion_list, outcar_path)
+            total_magnetic_moment = mag_data['tot'].sum()
+            if np.isclose(total_magnetic_moment, 0,  atol=magmom_tolerance) == True:
+                afm = True
+            else:
+                afm = False
+            
             row = {
                 "volume": vol,
                 "config": config,
                 "energy": energy,
                 "number_of_atoms": number_of_atoms,
-                "mag_data": mag_data,
+                "total_magnetic_moment": total_magnetic_moment,
+                "afm": afm,
+                "mag_data": mag_data
             }
         else:
             row = {

--- a/dfttk/workflows.py
+++ b/dfttk/workflows.py
@@ -181,11 +181,11 @@ def extract_mag_data(outcar_path="OUTCAR"):
         return df
 
 
-def extract_tot_mag_data(ion_list, outcar_path="OUTCAR"):
+#TODO just get mag data for all the ions
+def extract_tot_mag_data(outcar_path="OUTCAR"):
     """Returns only the 'tot' magnetization of the last step for each specified ion.
 
     Args:
-        ion_list (list): The ion_list should be a list of integers ex: [1, 2, 3, 4].
         outcar_path (str, optional): Path to an OUTCAR file. Defaults to "OUTCAR".
 
     Returns:
@@ -194,9 +194,7 @@ def extract_tot_mag_data(ion_list, outcar_path="OUTCAR"):
 
     all_mag_data = extract_mag_data(outcar_path)
     last_step_data = all_mag_data[all_mag_data["step"] == all_mag_data["step"].max()]
-    tot_data = last_step_data[last_step_data["# of ion"].isin(ion_list)][
-        ["# of ion", "tot"]
-    ]
+    tot_data = last_step_data[["# of ion", "tot"]]
     tot_data.reset_index(drop=True, inplace=True)
     return tot_data
 
@@ -208,7 +206,6 @@ def extract_configuration_data(
     oszicar_name: str ='OSZICAR.3static',
     contcar_name: str ='CONTCAR.3static', 
     collect_mag_data: bool = False,
-    ion_list: list[int] = [1],
     magmom_tolerance: float = 0
 ):
     """Extracts the volume, configuration, energy, number of atoms, and magnetization data (if specified) from calculations 
@@ -221,7 +218,6 @@ def extract_configuration_data(
         contcar_name: name of the CONTCAR file. Defaults to "CONTCAR".
         collect_mag_data: if True, collect the magnetization data using extract_tot_mag_data. Defaults to
         False.
-        ion_list: specifies the ions to collect magnetization data for -- corresponds to '# of ion' in the
         OUTCAR. Defaults to [1].
         magmom_tolerance: the tolerance for the total magnetic moment to be considered zero. Defaults to 0.
 
@@ -256,7 +252,7 @@ def extract_configuration_data(
         vol = extract_volume(contcar_path)
         energy = extract_energy(oszicar_path)
         if collect_mag_data == True:
-            mag_data = extract_tot_mag_data(ion_list, outcar_path)
+            mag_data = extract_tot_mag_data(outcar_path)
             total_magnetic_moment = mag_data['tot'].sum()
             if np.isclose(total_magnetic_moment, 0,  atol=magmom_tolerance) == True:
                 afm = True
@@ -290,7 +286,6 @@ def recursive_extract_configuration_data(
     oszicar_name: str ='OSZICAR',
     contcar_name: str ='CONTCAR', 
     collect_mag_data: bool = False,
-    ion_list: list[int] = [1],
     magmom_tolerance: float = 0
     ):
     """convenience function to extract configuration data from multiple config directories.
@@ -303,7 +298,6 @@ def recursive_extract_configuration_data(
         contcar_name: name of the CONTCAR file. Defaults to "CONTCAR".
         collect_mag_data: if True, collect the magnetization data using extract_tot_mag_data. Defaults to
         False.
-        ion_list: specifies the ions to collect magnetization data for -- corresponds to '# of ion' in the
         OUTCAR. Defaults to [1].
         magmom_tolerance: the tolerance for the total magnetic moment to be considered zero. Defaults to 0.
         


### PR DESCRIPTION

- **update to extract_configuration_data**

  - When collect_mag_data = True, includes additional columns for 'total_magnetic_moment' of the cell and 'afm'.

- **removed optional parameter ion_list**
deleted all appearances of ion_list from workflows.py. It now always collects data for all ions.


- **workflows.recursive_extract_configuration_data**: convenience function for iterating through a list of config_dirs

  `dfr = workflows.recursive_extract_configuration_data(config_dirs, outcar_name='OUTCAR.3static', oszicar_name='OSZICAR.3static', contcar_name='CONTCAR.3static', collect_mag_data=True)
  print(dfr.drop(columns='mag_data'))`
  
  ```
          volume config     energy  number_of_atoms  total_magnetic_moment   afm
  0   355.714286    23c -230.86150               16                    0.0  True
  1   348.571429    23c -230.91777               16                    0.0  True
  2   320.000000    23c -230.99078               16                    0.0  True
  3   312.857143    23c -230.94975               16                    0.0  True
```
