### PR TITLE
Mag_data update + plot_mv() bug fix. + plot_config_energy() update

### DIFF
--- a/dfttk/eos_fit.py
+++ b/dfttk/eos_fit.py
@@ -1570,7 +1570,7 @@ def plot_config_energy(
             showgrid=False
         ),
         yaxis2=dict(
-            domain=[0.6, 0.95],
+            domain=[0.5, 0.95],
             anchor='x2',
             range=[0, ymaxs[1]],
             showline=True,

--- a/dfttk/eos_fit.py
+++ b/dfttk/eos_fit.py
@@ -1528,9 +1528,17 @@ def plot_config_energy(
         ymax = ((ymax // rounding_order_of_magnitude) + 1) * rounding_order_of_magnitude
         ymaxs.append(ymax)
         if i == 0:
-            data.append(go.Scatter(x=new_df["rank"], y=new_df["energy_difference"], mode="markers"))
+            data.append(go.Scatter(x=new_df["rank"],
+                                   y=new_df["energy_difference"],
+                                   mode="markers",
+                                   hovertext=[f'config = {i}' for i in new_df["config"]]))
         else:
-            data.append(go.Scatter(x=new_df["rank"], y=new_df["energy_difference"], xaxis='x2', yaxis='y2', mode="markers"))
+            data.append(go.Scatter(x=new_df["rank"],
+                                   y=new_df["energy_difference"],
+                                   xaxis='x2',
+                                   yaxis='y2',
+                                   mode="markers",
+                                   hovertext=[f'config={i}' for i in new_df["config"]]))
     layout = go.Layout(
         xaxis=dict(
             title="Energy rank",

--- a/dfttk/eos_fit.py
+++ b/dfttk/eos_fit.py
@@ -1501,16 +1501,8 @@ def plot_config_energy(
     df, number_of_lowest_configs=5, show_fig=True, xmax=None, ymax=None
 ):
     new_df = df
-    try:
-        new_df = df.drop("# of ion", axis=1)
-        new_df = new_df.drop("tot", axis=1)
-        new_df = new_df.drop_duplicates()
-        new_df["energy_per_atom"] = new_df["energy"] / new_df["number_of_atoms"]
-        new_df = new_df.nsmallest(number_of_lowest_configs, "energy_per_atom").copy()
-    except Exception as e:
-        print("possible error. Could not strip magnetic data: ", e)
-        new_df["energy_per_atom"] = new_df["energy"] / new_df["number_of_atoms"]
-        new_df = df.nsmallest(number_of_lowest_configs, "energy_per_atom").copy()
+    new_df["energy_per_atom"] = new_df["energy"] / new_df["number_of_atoms"]
+    new_df = df.nsmallest(number_of_lowest_configs, "energy_per_atom").copy()
     new_df["energy_difference"] = (
         new_df["energy_per_atom"] - new_df["energy_per_atom"].min()
     ) * 1000

--- a/dfttk/eos_fit.py
+++ b/dfttk/eos_fit.py
@@ -1540,29 +1540,36 @@ def plot_config_energy(
                                    mode="markers",
                                    hovertext=[f'config={i}' for i in new_df["config"]]))
     layout = go.Layout(
+        font=dict(
+            family="Devaju Sans",
+            size=20,
+            color="black"
+        ),
         xaxis=dict(
             title="Energy rank",
             range=[0, xmaxs[0]],
             showline=True,
             linecolor="black",
-            linewidth=2.4,
-            ticks="inside",
+            linewidth=1,
+            ticks="outside",
             mirror="allticks",
-            tickwidth=2.4,
+            tickwidth=1,
             tickcolor="black",
-            showgrid=False
+            showgrid=False,
+            tickfont=dict(color="rgb(0,0,0)", size=20)
         ),
         yaxis=dict(
             title="Energy difference (meV/atom)",
             range=[0, ymaxs[0]],
             showline=True,
             linecolor="black",
-            linewidth=2.4,
-            ticks="inside",
+            linewidth=1,
+            ticks="outside",
             mirror="allticks",
-            tickwidth=2.4,
+            tickwidth=1,
             tickcolor="black",
-            showgrid=False
+            showgrid=False,
+            tickfont=dict(color="rgb(0,0,0)", size=20)
         ),
         xaxis2=dict(
             domain=[0.1, 0.5],
@@ -1570,12 +1577,13 @@ def plot_config_energy(
             range=[0, inset_max_rank],
             showline=True,
             linecolor="black",
-            linewidth=2.4,
-            ticks="inside",
+            linewidth=1,
+            ticks="outside",
             mirror="allticks",
-            tickwidth=2.4,
+            tickwidth=1,
             tickcolor="black",
-            showgrid=False
+            showgrid=False,
+            tickfont=dict(color="rgb(0,0,0)", size=20)
         ),
         yaxis2=dict(
             domain=[0.5, 0.95],
@@ -1583,22 +1591,23 @@ def plot_config_energy(
             range=[0, ymaxs[1]],
             showline=True,
             linecolor="black",
-            linewidth=2.4,
-            ticks="inside",
+            linewidth=1,
+            ticks="outside",
             mirror="allticks",
-            tickwidth=2.4,
+            tickwidth=1,
             tickcolor="black",
-            showgrid=False
+            showgrid=False,
+            tickfont=dict(color="rgb(0,0,0)", size=20)
         ),
         plot_bgcolor="white",
         width=600,
         height=600,
-        margin=dict(l=80, r=30, t=80, b=80),
+        margin=dict(l=80, r=30, t=30, b=80),
         showlegend=False
     )
     fig = go.Figure(data=data, layout=layout)
     fig.update_traces(
-        marker=dict(size=5, symbol="cross-thin-open", color="blue"),
+        marker=dict(size=6, symbol="cross-thin-open", color="blue"),
         selector=dict(mode="markers"),
     )
     if show_fig:

--- a/dfttk/eos_fit.py
+++ b/dfttk/eos_fit.py
@@ -750,9 +750,11 @@ def plot_mv(df, show_fig=True):
     df is a data frame with columns ['config', '# of ion', 'volume', 'tot']
     breaks if missing these columns
     """
+    # Create a new dataframe where each 'mag_data' dataframe is associated with its corresponding 'volume' and 'config' values
+    df_new = pd.concat([df_mag.assign(volume=v, config=c) for v, c, df_mag in zip(df['volume'], df['config'], df['mag_data'])])
 
     fig = px.line(
-        df,
+        df_new.sort_values('volume'),
         x="volume",
         y="tot",
         color="# of ion",
@@ -761,7 +763,7 @@ def plot_mv(df, show_fig=True):
         template="plotly_white",
     )
     fig.update_layout(
-        title="Mag-V", xaxis_title="Volume [A^3]", yaxis_title="Magnetic Moment [mu_B]"
+        xaxis_title="Volume [A^3]", yaxis_title="Magnetic Moment [mu_B]"
     )
 
     fig.update_yaxes(nticks=10)

--- a/dfttk/eos_fit.py
+++ b/dfttk/eos_fit.py
@@ -1498,7 +1498,7 @@ def plot_energy_difference(
 
 # TODO: review
 def plot_config_energy(
-    df, max_rank=5, show_fig=True, xmax=None, ymax=None, inset_max_rank=10
+    df, max_rank=5, show_fig=True, xmax=None, ymax=None, inset=True, inset_max_rank=10,
 ):
     data = []
     xmaxs = []
@@ -1605,6 +1605,8 @@ def plot_config_energy(
         margin=dict(l=80, r=30, t=30, b=80),
         showlegend=False
     )
+    if inset==False:
+        data.pop(1)
     fig = go.Figure(data=data, layout=layout)
     fig.update_traces(
         marker=dict(size=6, symbol="cross-thin-open", color="blue"),

--- a/dfttk/eos_fit.py
+++ b/dfttk/eos_fit.py
@@ -752,9 +752,8 @@ def plot_mv(df, show_fig=True):
     """
     # Create a new dataframe where each 'mag_data' dataframe is associated with its corresponding 'volume' and 'config' values
     df_new = pd.concat([df_mag.assign(volume=v, config=c) for v, c, df_mag in zip(df['volume'], df['config'], df['mag_data'])])
-
     fig = px.line(
-        df_new.sort_values('volume'),
+        df_new.sort_values(['# of ion','volume',]),
         x="volume",
         y="tot",
         color="# of ion",

--- a/dfttk/eos_fit.py
+++ b/dfttk/eos_fit.py
@@ -1498,7 +1498,7 @@ def plot_energy_difference(
 
 # TODO: review
 def plot_config_energy(
-    df, max_rank=5, show_fig=True, xmax=None, ymax=None, inset=True, inset_max_rank=10,
+    df, max_rank=5, show_fig=True, xmax=None, ymax=None, show_inset=True, inset_max_rank=10,
 ):
     data = []
     xmaxs = []
@@ -1605,7 +1605,7 @@ def plot_config_energy(
         margin=dict(l=80, r=30, t=30, b=80),
         showlegend=False
     )
-    if inset==False:
+    if show_inset==False:
         data.pop(1)
     fig = go.Figure(data=data, layout=layout)
     fig.update_traces(

--- a/dfttk/workflows.py
+++ b/dfttk/workflows.py
@@ -210,13 +210,13 @@ def determine_magnetic_ordering(df: pd.DataFrame, magmom_tolerance: float = 0):
 
     if (df['tot'] == 0).all():
         return 'NM'
-    elif np.isclose(df['tot'].sum(), 0,  atol=0) == True:
+    elif np.isclose(df['tot'].sum(), 0,  atol=magmom_tolerance) == True:
         return 'AFM'
     elif (df['tot'] >= 0).all() or (df['tot'] <= 0).all():
         return 'FM'
     elif (df['tot'] > 0).sum() == (df['tot'] < 0).sum():
         return 'FiM'
-    else :
+    else:
         return 'SF'
 
   

--- a/dfttk/workflows.py
+++ b/dfttk/workflows.py
@@ -198,6 +198,27 @@ def extract_tot_mag_data(outcar_path="OUTCAR"):
     tot_data.reset_index(drop=True, inplace=True)
     return tot_data
 
+def determine_magnetic_ordering(df: pd.DataFrame, magmom_tolerance: float = 0):
+    """Determines the magnetic ordering of a structure from the magnetization data in a pandas DataFrame.
+
+    Args:
+        df (pandas DataFrame): a pandas DataFrame containing the magnetization data
+
+    Returns:
+        str: the magnetic ordering of the structure
+    """
+
+    if (df['tot'] == 0).all():
+        return 'NM'
+    elif np.isclose(df['tot'].sum(), 0,  atol=0) == True:
+        return 'AFM'
+    elif (df['tot'] >= 0).all() or (df['tot'] <= 0).all():
+        return 'FM'
+    elif (df['tot'] > 0).sum() == (df['tot'] < 0).sum():
+        return 'FiM'
+    else :
+        return 'SF'
+
   
 def extract_configuration_data(
     path: list[str],
@@ -320,7 +341,8 @@ def recursive_extract_configuration_data(
             config_df = extract_configuration_data(
                 config_dir, outcar_name=outcar_name, 
                 oszicar_name=oszicar_name, contcar_name=contcar_name, 
-                collect_mag_data=collect_mag_data)
+                collect_mag_data=collect_mag_data,
+                magmom_tolerance=magmom_tolerance)
             df_list.append(config_df)
         except Exception as e:
             print(f'Error in {config_dir}: {e}')

--- a/dfttk/workflows.py
+++ b/dfttk/workflows.py
@@ -203,6 +203,8 @@ def determine_magnetic_ordering(df: pd.DataFrame, magmom_tolerance: float = 0):
 
     Args:
         df (pandas DataFrame): a pandas DataFrame containing the magnetization data
+        magmom_tolerance (float, optional): the tolerance for the total magnetic moment to be considered
+        zero. Defaults to 0.
 
     Returns:
         str: the magnetic ordering of the structure
@@ -276,17 +278,7 @@ def extract_configuration_data(
         if collect_mag_data == True:
             mag_data = extract_tot_mag_data(outcar_path)
             total_magnetic_moment = mag_data['tot'].sum()
-            
-            if (mag_data['tot'] == 0).all():
-                magnetic_ordering = 'NM'
-            elif np.isclose(total_magnetic_moment, 0,  atol=magmom_tolerance) == True:
-                magnetic_ordering = 'AFM'
-            elif (mag_data['tot'] >= 0).all() or (mag_data['tot'] <= 0).all():
-                magnetic_ordering = 'FM'
-            elif (mag_data['tot'] > 0).sum() == (mag_data['tot'] < 0).sum():
-                magnetic_ordering = 'FiM'
-            else :
-                magnetic_ordering = 'SF'
+            magnetic_ordering = determine_magnetic_ordering(mag_data)
             
             row = {
                 "config": config,


### PR DESCRIPTION
### determine_magnetic_ordering()

- decoupled this from extract_configuration_data()
- Introduced magmom_tolerance and total_magmom_tolerance for determining the magnetic ordering. The default values are  1e-12 just to avoid floating point errors.

### extract_mag_data() bug fix

- previously only worked if the outcar magnetization (x) data had headers "# of ion", "s", "p", "d", "tot". Now works for any combination of headers. e.g. "# of ion", "s", "p", "d",  "f", "tot"

### plot_mv()

- updated to work with the outputs from extract_configuration_data(). I don't think it ever got updated it, after removing extract_config_data().