### PR TITLE
bug fix in ev_curve_series for keep_wavecar=True

### DIFF
--- a/dfttk/workflows.py
+++ b/dfttk/workflows.py
@@ -616,6 +616,10 @@ def ev_curve_series(
         "PROCAR.2relax",
         "PROCAR.3static",
     ]
+    if keep_wavecar:
+        files_to_delete.remove("WAVECAR.3static")
+    if keep_chgcar:
+        files_to_delete.remove("CHGCAR.3static")
 
     # This starts the EV curve calculations in series. If restarting, skip the volumes that have already been completed.
     for i, vol in enumerate(volumes):
@@ -650,10 +654,6 @@ def ev_curve_series(
                 if os.path.isfile(file_source):
                     shutil.copy2(file_source, file_dest)
 
-            if keep_wavecar:
-                files_to_delete.remove("WAVECAR.3static")
-            if keep_chgcar:
-                files_to_delete.remove("CHGCAR.3static")
             paths_to_delete = []
 
             for file_name in files_to_delete:


### PR DESCRIPTION
moved lines outside of the loop, since files_to_delete.remove("WAVECAR.3static") can only be done once.

When it was in the loop, it would attempt to remove a second time and error.