### PR TITLE
Update qha_yphon.py, vasp_input.py, workflows.py

### DIFF
--- a/dfttk/mongo.py
+++ b/dfttk/mongo.py
@@ -1,0 +1,114 @@
+"""
+Store results on MongoDB.
+"""
+
+# Standard library imports
+import json
+import os
+
+# Third-party library imports
+import numpy as np
+from natsort import natsorted
+from pymongo import MongoClient
+from pymatgen.io.vasp.inputs import Incar, Kpoints, Poscar, Potcar
+
+# DFTTK imports
+from dfttk.aggregate_extraction import extract_configuration_data
+from dfttk.eos_fit import fit_to_all_eos
+from dfttk.workflows import custodian_errors_location
+
+class MongoDBStorage:
+
+    # Establish connection to MongoDB
+    def __init__(self, path: str, connection_string: str):
+        self.cluster = MongoClient(connection_string)
+        self.db = self.cluster["DFTTK"]
+        self.collection = self.db["community"]
+        self.path = path
+
+    def store_ev_curve(self, eos: str = "BM4"):
+        vol_folders = [
+            f
+            for f in os.listdir(self.path)
+            if os.path.isdir(os.path.join(self.path, f)) and f.startswith("vol")
+        ]
+        vol_folders = natsorted(vol_folders)
+        
+        # material
+        poscar = Poscar.from_file(
+            os.path.join(self.path, vol_folders[0], "POSCAR.1relax")
+        )
+        formula = (poscar.structure.composition.formula)
+        reduced_formula = (poscar.structure.composition.reduced_formula)
+        number_of_atoms = (poscar.structure.composition.num_atoms)
+
+        # properties
+        ## EV curve
+        #TODO: If there are errors in all vol_folders, this will not work
+        vol_folders_errors = custodian_errors_location(self.path)
+        vol_folders_no_errors = [f for f in vol_folders if f not in vol_folders_errors]
+        
+        incar_relax = Incar.from_file(
+            os.path.join(self.path, vol_folders_no_errors[0], "INCAR.1relax")
+        )
+        incar_static = Incar.from_file(
+            os.path.join(self.path, vol_folders_no_errors[0], "INCAR.3static")
+        )
+        kpoints = Kpoints.from_file(
+            os.path.join(self.path, vol_folders_no_errors[0], "KPOINTS.1relax")
+        )
+        potcar = Potcar.from_file(os.path.join(self.path, vol_folders_no_errors[0], "POTCAR"))
+
+        df = extract_configuration_data(
+            self.path,
+            outcar_name="OUTCAR.3static",
+            contcar_name="CONTCAR.3static",
+            oszicar_name="OSZICAR.3static",
+        )
+        
+        eos_df, eos_parameters_df = fit_to_all_eos(df)
+        eos_df = eos_df.drop(columns=["config", "a", "b", "c", "d", "e", "number_of_atoms"])
+        eos_df = eos_df[eos_parameters_df['EOS'] == "BM4"]
+        eos_df['volumes'] = eos_df['volumes'].apply(lambda x: x.tolist() if isinstance(x, np.ndarray) else x)
+        eos_df['energies'] = eos_df['energies'].apply(lambda x: x.tolist() if isinstance(x, np.ndarray) else x)
+        eos_df['pressures'] = eos_df['pressures'].apply(lambda x: x.tolist() if isinstance(x, np.ndarray) else x)
+        eos_dict = eos_df.to_dict(orient="records")[0]
+        
+        df = df.drop(columns=["config", "number_of_atoms"])
+        df_dict = df.to_dict(orient="records")
+
+        error_dict = {}
+        for f in vol_folders_errors:
+            file_path = os.path.join(self.path, f, "custodian.json")
+            with open(file_path, 'r') as file:
+                error_dict[f] = json.load(file)
+        
+        ev_curve_properties = {}
+        ev_curve_properties["VASP input"] = {
+            "INCAR relax": incar_relax,
+            "INCAR static": incar_static,
+            "KPOINTS": kpoints.as_dict(),
+            "POTCAR": potcar.as_dict(),
+            "errors": error_dict
+        }
+        
+        i = 0
+        for vol_folder in vol_folders:
+            poscar = Poscar.from_file(os.path.join(self.path, vol_folder, "POSCAR.3static"))
+            df_dict[i]["POSCAR"] = poscar.as_dict()
+            ev_curve_properties[vol_folder] = df_dict[i]
+            i += 1
+        
+        ev_curve_properties["EOS fit"] = eos_dict
+
+        document = {
+            "material": {
+                "formula": formula,
+                "reduced formula": reduced_formula,
+                "number of atoms": number_of_atoms,
+            },
+            "properties": {"EV curve": ev_curve_properties},
+        }
+        self.collection.insert_one(document)
+        return document
+    

--- a/dfttk/qha_yphon.py
+++ b/dfttk/qha_yphon.py
@@ -832,7 +832,7 @@ def plot_quasi_harmonic(
         plot_format(
             fig,
             f"Temperature (K)",
-            f"Entropy eV/K/{scale_atoms} atoms",
+            f"Entropy (eV/K/{scale_atoms} atoms)",
             width=600,
             height=600,
         )
@@ -855,7 +855,7 @@ def plot_quasi_harmonic(
         plot_format(
             fig,
             f"Temperature (K)",
-            f"C<sub>p</sub> eV/K/{scale_atoms} atoms",
+            f"C<sub>p</sub> (eV/K/{scale_atoms} atoms)",
             width=600,
             height=600,
         )

--- a/dfttk/vasp_input.py
+++ b/dfttk/vasp_input.py
@@ -11,6 +11,107 @@ import numpy as np
 from pymatgen.core.structure import Structure
 from pymatgen.io.vasp.inputs import Poscar, Kpoints, Incar, Potcar
 
+# TODO: It may be good to move this long constant to another file
+POTCAR_DICT = {
+    "Ac": "Ac",
+    "Ag": "Ag",
+    "Al": "Al",
+    "Am": "Am",
+    "Ar": "Ar",
+    "As": "As",
+    "At": "At",
+    "Au": "Au",
+    "B": "B",
+    "Ba": "Ba_sv",
+    "Be": "Be_sv",
+    "Bi": "Bi",
+    "Br": "Br",
+    "C": "C",
+    "Ca": "Ca_sv",
+    "Cd": "Cd",
+    "Ce": "Ce",
+    "Cf": "Cf",
+    "Cl": "Cl",
+    "Cm": "Cm",
+    "Co": "Co",
+    "Cr": "Cr_pv",
+    "Cs": "Cs_sv",
+    "Cu": "Cu_pv",
+    "Dy": "Dy_3",
+    "Er": "Er_3",
+    "Eu": "Eu",
+    "F": "F",
+    "Fe": "Fe_pv",
+    "Fr": "Fr_sv",
+    "Ga": "Ga_d",
+    "Gd": "Gd",
+    "Ge": "Ge_d",
+    "H": "H",
+    "He": "He",
+    "Hf": "Hf_pv",
+    "Hg": "Hg",
+    "Ho": "Ho_3",
+    "I": "I",
+    "In": "In_d",
+    "Ir": "Ir",
+    "K": "K_sv",
+    "Kr": "Kr",
+    "La": "La",
+    "Li": "Li_sv",
+    "Lu": "Lu_3",
+    "Mg": "Mg_pv",
+    "Mn": "Mn_pv",
+    "Mo": "Mo_pv",
+    "N": "N",
+    "Na": "Na_pv",
+    "Nb": "Nb_pv",
+    "Nd": "Nd_3",
+    "Ne": "Ne",
+    "Ni": "Ni_pv",
+    "Np": "Np",
+    "O": "O",
+    "Os": "Os_pv",
+    "P": "P",
+    "Pa": "Pa",
+    "Pb": "Pb_d",
+    "Pd": "Pd",
+    "Pm": "Pm_3",
+    "Po": "Po_d",
+    "Pr": "Pr_3",
+    "Pt": "Pt",
+    "Pu": "Pu",
+    "Ra": "Ra_sv",
+    "Rb": "Rb_sv",
+    "Re": "Re_pv",
+    "Rh": "Rh_pv",
+    "Rn": "Rn",
+    "Ru": "Ru_pv",
+    "S": "S",
+    "Sb": "Sb",
+    "Sc": "Sc_sv",
+    "Se": "Se",
+    "Si": "Si",
+    "Sm": "Sm_3",
+    "Sn": "Sn_d",
+    "Sr": "Sr_sv",
+    "Ta": "Ta_pv",
+    "Tb": "Tb_3",
+    "Tc": "Tc_pv",
+    "Te": "Te",
+    "Th": "Th",
+    "Ti": "Ti_sv",
+    "Tl": "Tl_d",
+    "Tm": "Tm_3",
+    "U": "U",
+    "V": "V_pv",
+    "W": "W_sv",
+    "Xe": "Xe",
+    "Y": "Y_sv",
+    "Yb": "Yb_3",
+    "Zn": "Zn",
+    "Zr": "Zr_sv",
+}
+
 
 def base_set(
     path: str,
@@ -20,15 +121,17 @@ def base_set(
     potcar_functional: str = "PBE_54",
     incar_functional: str = "PBE",
 ) -> None:
-    
+
     poscar_path = os.path.join(path, "POSCAR")
     struct = Structure.from_file(poscar_path)
 
     kpoints = Kpoints.automatic_density(struct, kppa, force_gamma=True)
     kpoints.write_file(os.path.join(path, "KPOINTS"))
-    
+
     potcar_symbols = [site.specie.symbol for site in struct.sites]
-    potcar = Potcar(symbols=potcar_symbols, functional=potcar_functional)
+    unique_potcar_symbols = list(dict.fromkeys(potcar_symbols))
+    unique_potcar_symbols = [POTCAR_DICT[symbol] for symbol in unique_potcar_symbols]
+    potcar = Potcar(symbols=unique_potcar_symbols, functional=potcar_functional)
     potcar.write_file(os.path.join(path, "POTCAR"))
 
     incar_settings = {
@@ -41,27 +144,27 @@ def base_set(
         "LWAVE": False,
         "LCHARG": False,
     }
-    
+
     # TODO: Include all possible functionals
     # For more details, see: https://www.vasp.at/wiki/index.php/GGA and https://www.vasp.at/wiki/index.php/METAGGA
     incar_functional_settings = {
-    "PBE": {"GGA": "PE"},
-    "PBEsol": {"GGA": "PS"},
-    "r2SCAN": {"METAGGA": "R2SCAN", "LASPH": True},
+        "PBE": {"GGA": "PE"},
+        "PBEsol": {"GGA": "PS"},
+        "r2SCAN": {"METAGGA": "R2SCAN", "LASPH": True},
     }
 
     incar_settings.update(incar_functional_settings.get(incar_functional, {}))
-    
+
     material_settings = {
         "metal": {"ISMEAR": 1, "SIGMA": 0.2},
         "non_metal": {"ISMEAR": 0, "SIGMA": 0.05},
     }
 
     incar_settings.update(material_settings.get(material_type, {}))
-    
+
     return incar_settings
-    
-    
+
+
 def volume_relax_set(
     path: str,
     material_type: str,
@@ -71,7 +174,9 @@ def volume_relax_set(
     incar_functional: str = "PBE",
 ) -> None:
 
-    incar_settings = base_set(path, material_type, encut, kppa, potcar_functional, incar_functional)
+    incar_settings = base_set(
+        path, material_type, encut, kppa, potcar_functional, incar_functional
+    )
     incar_settings.update(
         {
             "ENCUT": encut,
@@ -80,7 +185,7 @@ def volume_relax_set(
             "NSW": 200,
         }
     )
-    
+
     incar = Incar(incar_settings)
     incar.write_file(os.path.join(path, "INCAR"))
 
@@ -91,10 +196,13 @@ def conv_set(
     kppa: int = 4000,
     potcar_functional: str = "PBE_54",
     incar_functional: str = "PBE",
+    other_settings: dict = {},
 ) -> None:
-    
-    material_type = "metal" # Will be overwridden by ISMEAR = -5
-    incar_settings = base_set(path, material_type, encut, kppa, potcar_functional, incar_functional)
+
+    material_type = "metal"  # Will be overwridden by ISMEAR = -5
+    incar_settings = base_set(
+        path, material_type, encut, kppa, potcar_functional, incar_functional
+    )
     incar_settings.update(
         {
             "ENCUT": encut,
@@ -104,9 +212,11 @@ def conv_set(
             "NSW": 0,
         }
     )
+    incar_settings.update(other_settings)
+
     incar = Incar(incar_settings)
     incar.write_file(os.path.join(path, "INCAR"))
-    
+
 
 def ev_curve_set(
     path: str,
@@ -118,7 +228,9 @@ def ev_curve_set(
     other_settings: dict = {},
 ) -> None:
 
-    incar_settings = base_set(path, material_type, encut, kppa, potcar_functional, incar_functional)
+    incar_settings = base_set(
+        path, material_type, encut, kppa, potcar_functional, incar_functional
+    )
     incar_settings.update(
         {
             "ENCUT": encut,
@@ -133,22 +245,28 @@ def ev_curve_set(
     incar.write_file(os.path.join(path, "INCAR"))
 
 
-def perturb_structure(path, displacement_magnitude, atoms_to_perturb, number_of_perturbations):    
+def perturb_structure(
+    path, displacement_magnitude, atoms_to_perturb, number_of_perturbations
+):
     parent_dir = os.path.dirname(path)
-    
+
     structure = Poscar.from_file(path).structure
-    
+
     for i in range(number_of_perturbations):
         structure_copy = structure.copy()
-        
+
         # Same magnitude, but different vector components for each perturbation on each atom
         for atom in atoms_to_perturb:
             random_vector = np.random.rand(3) - 0.5
             random_vector_magnitude = np.linalg.norm(random_vector)
             normalized_random_vector = random_vector / random_vector_magnitude
             displacement_vector = normalized_random_vector * displacement_magnitude
-            structure_copy[atom].coords = structure_copy[atom].coords + displacement_vector
+            structure_copy[atom].coords = (
+                structure_copy[atom].coords + displacement_vector
+            )
 
         perturbed_structure = Poscar(structure_copy)
-        os.makedirs(os.path.join(parent_dir, f'perturb_{i}'))
-        perturbed_structure.write_file(os.path.join(parent_dir, f'perturb_{i}', 'POSCAR'))
+        os.makedirs(os.path.join(parent_dir, f"perturb_{i}"))
+        perturbed_structure.write_file(
+            os.path.join(parent_dir, f"perturb_{i}", "POSCAR")
+        )

--- a/dfttk/workflows.py
+++ b/dfttk/workflows.py
@@ -453,13 +453,17 @@ def charge_density_difference(
     return difference
 
 
-def custodian_errors_location(path: str) -> None:
+def custodian_errors_location(path: str) -> list[str]:   
     """Prints the location of the custodian errors in the path.
 
     Args:
         path (str): path to the folder containing all the calculation folders. E.g. vol_1, phonon_1, etc.
+    
+    Returns:
+        list[str]: volume folders that encountered VASP errors
     """
 
+    vol_folders_errors = []
     vol_folders = [d for d in os.listdir(path) if d.startswith("vol")]
     for vol_folder in vol_folders:
         error_folders = [
@@ -469,6 +473,9 @@ def custodian_errors_location(path: str) -> None:
         ]
         if len(error_folders) > 0:
             print(f"In {vol_folder} there are error folders: {error_folders}")
+            vol_folders_errors.append(vol_folder)
+    
+    return vol_folders_errors
 
 
 def NELM_reached(path: str) -> None:


### PR DESCRIPTION
qha_yphon.py - Some plot labels were missing brackets. Added those.

vasp_input.py
- Added POTCAR_DICT for default pseudopotentials. It may be worthwhile to move this to a separate file.
- There was a problem with the POTCAR file concatenating all the possible atoms in the POSCAR file. For example if the POSCAR file had 4 Al atoms it would concatenate the Al POTCAR file 4 times. This was fixed.

workflows.py
- Added a return to custodian_errors_location to return vol_folders with VASP errors. Useful for storing on MongoDB.