### PR TITLE
Debye-Gruneisen Model

### DIFF
--- a/dfttk/aggregate_extraction.py
+++ b/dfttk/aggregate_extraction.py
@@ -25,6 +25,7 @@ from dfttk.data_extraction import (
     extract_energy,
     extract_tot_mag_data,
     extract_kpoints,
+    extract_atomic_masses
 )
 from dfttk.magnetism import determine_magnetic_ordering
 
@@ -85,6 +86,7 @@ def extract_configuration_data(
         energy_per_atom = energy / number_of_atoms
         vol_per_atom = vol / number_of_atoms
         space_group = SpacegroupAnalyzer(struct).get_space_group_symbol()
+        atomic_masses = extract_atomic_masses(outcar_path)
         if collect_mag_data == True:
             mag_data = extract_tot_mag_data(outcar_path)
             total_magnetic_moment = mag_data["tot"].sum()
@@ -101,6 +103,8 @@ def extract_configuration_data(
                 "volume_per_atom": vol_per_atom,
                 "energy": energy,
                 "energy_per_atom": energy_per_atom,
+                "space_group": space_group,
+                "atomic_masses": atomic_masses,
                 "total_magnetic_moment": total_magnetic_moment,
                 "magnetic_ordering": magnetic_ordering,
                 "mag_data": mag_data,
@@ -114,6 +118,7 @@ def extract_configuration_data(
                 "energy": energy,
                 "energy_per_atom": energy_per_atom,
                 "space_group": space_group,
+                "atomic_masses": atomic_masses,
             }
         row_list.append(row)
     df = pd.DataFrame(row_list)

--- a/dfttk/aggregate_extraction.py
+++ b/dfttk/aggregate_extraction.py
@@ -133,7 +133,6 @@ def extract_configuration_data(
     df = pd.DataFrame(row_list)
     return df
 
-
 def recursive_extract_configuration_data(
     config_dirs: list[str],
     outcar_name: str = "OUTCAR",

--- a/dfttk/data_extraction.py
+++ b/dfttk/data_extraction.py
@@ -98,6 +98,12 @@ def extract_energy(path: str) -> float:
                 break
     return energy
 
+def extract_mass(outcar_path: str) -> float:
+    """
+    Extract the mass of each atom from an OUTCAR file as a dictionary.
+    """
+    pass
+    
 
 def write_ev(path: str) -> None:
     """Function to write the volumes and energies obtained from ev_curve_series to a text file.

--- a/dfttk/data_extraction.py
+++ b/dfttk/data_extraction.py
@@ -98,11 +98,27 @@ def extract_energy(path: str) -> float:
                 break
     return energy
 
-def extract_mass(outcar_path: str) -> float:
+def extract_atomic_masses(outcar_path: str) -> float:
     """
-    Extract the mass of each atom from an OUTCAR file as a dictionary.
+    Extract the mass of each atom (POMASS values) from an OUTCAR file as a dictionary.
     """
-    pass
+    
+    atoms = []
+    masses = []
+    with open(outcar_path, "r") as file:
+        lines = file.readlines()
+        for line in lines:
+            if "TITEL" in line:
+                atoms.append(line.split()[-2])
+            elif "POMASS" in line:
+                mass = line.split()[2].replace(';', '')
+                masses.append(float(mass))
+                
+    # Clean atoms so that only the species is containted. e.g. 'Fe_pv' -> 'Fe'
+    atoms = [atom.split('_')[0] for atom in atoms]
+    
+    atomic_masses = dict(zip(atoms, masses))
+    return atomic_masses
     
 
 def write_ev(path: str) -> None:

--- a/dfttk/data_extraction.py
+++ b/dfttk/data_extraction.py
@@ -119,8 +119,25 @@ def extract_atomic_masses(outcar_path: str) -> float:
     
     atomic_masses = dict(zip(atoms, masses))
     return atomic_masses
-    
 
+def extract_average_mass(
+    contcar_path: str,
+    outcar_path: str,
+    average: str = 'arithmetic'
+) -> float:
+    atomic_masses = extract_atomic_masses(outcar_path)
+    structure = Structure.from_file(contcar_path)
+    masses = [atomic_masses[site.specie.symbol] for site in structure]
+    if average == 'arithmetic':
+        average_mass = sum(masses) / len(masses)
+    elif average == 'geometric':
+        average_mass = np.prod(masses)**(1/len(masses))
+    elif average == 'harmonic':
+        average_mass = len(masses) / sum([1/mass for mass in masses])
+    else:
+        raise ValueError(f"Average type {average} not recognized. Must be 'arithmetic', 'geometric', or 'harmonic'.")
+    return average_mass
+    
 def write_ev(path: str) -> None:
     """Function to write the volumes and energies obtained from ev_curve_series to a text file.
     The data will be obtained from vol_* folders.

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -67,7 +67,7 @@ def debye_function(x: float, order: int = 30):
             return 1 - 3/8*x + 3 * summation
         elif order == 2:
             return 1 - 3/8*x
-        elif order < 2:
+        else:
             # value error
             raise ValueError("Order of the debye function series expansion must be greater than or equal to 2.")
     else:
@@ -75,16 +75,29 @@ def debye_function(x: float, order: int = 30):
 
         
 
-def debye_function_derivative(x, n=3, order=5):
+def debye_function_derivative(x, order=30):
     """series expansion of the derivative of the debye function. valid for |𝑋|<2𝜋 and 𝑁≥1, comes from the expansion
     Gonzalez, I., Kondrashuk, I., Moll, V. H., & Vega, A. Analytic Expressions for Debye Functions and the Heat Capacity of a Solid. Mathematics, 10(10), 1745. https://doi.org/10.3390/math10101745
     and Abramowitz, M. and Stegun, I.A. eds., 1968. Handbook of mathematical functions with formulas, graphs, and mathematical tables (Vol. 55). US Government printing office.
     """
     
-    summation = sum(bernoulli(2*k)/((2*k+n)*gamma(2*k+1)) * 2*k*x**(2*k-1) for k in range(1, order-2))
-    return -n/(2*(n+1)) + n*summation
+    order = int(order)
+    
+    if x >= 0.7*np.pi:
+        summation = sum(-np.exp(-k*x)*(1 + 3/(k*x) + 9/(k**2*x**2) + 18/(k**3*x**3) + 18/(k**4*x**4)) for k in range(1, order))
+        return -3*np.pi**4/(5*x**4) - 3*summation
         
-    return -n/((2*n+1)) + n*summation
+    elif -2*np.pi < x < 0.7*np.pi:
+        if order > 1:
+            bern_list = bernoulli(2*(order-1))
+            summation = sum(bern_list[2*k]/((2*k+3)*gamma(2*k+1)) * 2*k*x**(2*k-1) for k in range(1, order))
+            return -3/8 + 3*summation
+        elif order == 1:
+            return -3/8
+        else:
+            raise ValueError("Order of the debye function derivative series expansion must be greater than or equal to 1.")
+    else:
+        raise ValueError("The debye function derivative series expansions used are only valid for x > -2𝜋")
 
 def vibrational_energy(temperature, theta):
     debye_value = debye_function(theta/temperature)

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -15,8 +15,8 @@ from dfttk.data_extraction import extract_atomic_masses
 A = 231.04
 BOLTZMANN = constants.physical_constants['Boltzmann constant in eV/K'][0]
 
-def scaling_factor():
-    pass
+def scaling_factor(temperature):
+    s = 0.75
 
 def gruneisen_constant():
     pass

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -18,7 +18,7 @@ BOLTZMANN = constants.physical_constants['Boltzmann constant in eV/K'][0]
 def scaling_factor():
     return 0.75
 
-def gruneisen_constant(temperature):
+def gruneisen_constant():
     return 1.0
 
 def gruneisen_parameter(bulk_modulus_prime, gruneisen_constant):

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -30,7 +30,7 @@ def gruneisen_parameter(
     """Calculates the gruneisen parameter
 
     Args:
-        bulk_modulus_prime: B_0', first derivative of the bulk modulus with respect to volume
+        bulk_modulus_prime: B_0', first derivative of the bulk modulus with respect to pressure
         gruneisen_x: x, Should be between 2/3 (high temperature) and 1 (low temperature)
 
     Returns:

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -66,7 +66,7 @@ def debye_temperature(
 
 def debye_function(
     x_array: np.array,
-    prec: float = 1e-10,
+    prec: float = 1e-12,
     nth_bernoulli: int = 100
 ) -> np.array:
     """Calculates the debye function with n=3 using one of two series expansions. Valid for |𝑋|<2𝜋 and 𝑁≥1,
@@ -127,7 +127,7 @@ def debye_function(
         
 def debye_function_derivative(
     x_array: np.array,
-    prec: float =1e-10,
+    prec: float =1e-12,
     nth_bernoulli: int = 100
 ) -> np.array:
     """Calculates the derivative of the debye function with n=3 using one of two series expansions. Valid for |𝑋|<2𝜋 and 𝑁≥1,
@@ -242,7 +242,7 @@ def plot_debye(
     number_of_atoms: int,
     y: np.array,
     y_label: str,
-    selected_temperatures: np.array | None = None,
+    selected_temperatures: np.array = None,
     volume_decimals: int = 0,
     temperature_decimals: int = 0
 ) -> tuple[go.Figure, go.Figure]:
@@ -290,7 +290,7 @@ def process_debye_gruneisen(
     config_path: str,
     scaling_factor: float = 0.617,
     gruneisen_constant: float = 1,
-    volumes: np.array | None = None,
+    volumes: np.array = None,
     temperatures: np.array = np.linspace(10, 1000, 100),
     outcar_name: str = "OUTCAR.3static",
     oszicar_name: str = "OSZICAR.3static",
@@ -329,7 +329,6 @@ def process_debye_gruneisen(
         magmom_tolerance = magmom_tolerance,
         total_magnetic_moment_tolerance = total_magnetic_moment_tolerance
     )
-    print(df)
     # fit the equation of state
     volume = df['volume']
     energy = df['energy']

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -222,7 +222,6 @@ def vibrational_helmholtz_energy(temperature: float, theta:float) -> float:
     debye_value = debye_function(x)
     return 9/8*BOLTZMANN*theta + BOLTZMANN*temperature*(3*np.log(1-np.exp(-x)) - debye_value)
 
-# TODO: fix. this equation is wrong
 def vibrational_heat_capacity(temperature: float, theta: float) -> float:
     """Evaluates the debye function and its derivative at x = theta/temperature then
     calculates the vibrational heat capacity in eV/K.
@@ -235,7 +234,8 @@ def vibrational_heat_capacity(temperature: float, theta: float) -> float:
         float: Vibrational heat capacity in eV/K
     """
     x = theta/temperature
-    return 3*BOLTZMANN*temperature*debye_function_derivative(x) + debye_function(x) # could probably optimize with property of derivative
+    debye_value = debye_function(x)
+    return  3*BOLTZMANN*(4*debye_value - 3*x/(np.exp(x)-1))
 
 def plot_debye(
     temperatures: np.array,
@@ -353,7 +353,7 @@ def process_debye_gruneisen(
     
     s_vib_v_t = np.zeros((len(volumes), len(temperatures)))
     f_vib_v_t = np.zeros((len(volumes), len(temperatures)))
-    cv_vib_v_t = np.zeros((len(volumes), len(temperatures)-1))
+    cv_vib_v_t = np.zeros((len(volumes), len(temperatures)))
     n = df['number_of_atoms'][0]
 
     for i, volume in enumerate(volumes):
@@ -361,13 +361,13 @@ def process_debye_gruneisen(
         debye_value = debye_function(x)
         s_vib = vibrational_entropy(temperatures, theta[i]) * n
         f_vib = vibrational_helmholtz_energy(temperatures, theta[i]) * n
-        # cv_vib = vibrational_heat_capacity(temperatures, theta[i]) * n
-        # Compute the differences between successive elements
-        d_s_vib = np.array([k - j for j, k in zip(s_vib[:-1], s_vib[1:])])
-        dt = np.array([k - j for j, k in zip(temperatures[:-1], temperatures[1:])])
-        cv_vib = temperatures[:-1] * d_s_vib / dt 
+        cv_vib = vibrational_heat_capacity(temperatures, theta[i]) * n
+        # # Compute the differences between successive elements
+        # d_s_vib = np.array([k - j for j, k in zip(s_vib[:-1], s_vib[1:])])
+        # dt = np.array([k - j for j, k in zip(temperatures[:-1], temperatures[1:])])
+        # cv_vib = temperatures[:-1] * d_s_vib / dt 
         s_vib_v_t[i, :] = s_vib
-        f_vib_v_t[i, :] = f_vib
+        f_vib_v_t[i, :] = f_vib 
         cv_vib_v_t[i, :] = cv_vib
     
     

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -1,5 +1,6 @@
 import os
 import numpy as np
+import plotly.graph_objects as go
 from scipy import constants
 from scipy.special import bernoulli
 from scipy.special import gamma
@@ -7,6 +8,7 @@ from pymatgen.io.vasp.outputs import Poscar
 from dfttk import eos_fit
 from dfttk.aggregate_extraction import extract_configuration_data
 from dfttk.data_extraction import extract_atomic_masses
+from dfttk.qha_yphon import plot_format
 
 
 
@@ -128,6 +130,40 @@ def vibrational_helmholtz_energy(temperature, theta):
 def vibrational_heat_capacity(temperature, theta):
     x = theta/temperature
     return 3*BOLTZMANN*temperature*debye_function_derivative(x) + debye_function(x)
+
+def plot_debye(
+    temperatures,
+    volumes,
+    y,
+    y_label,
+    selected_temperatures = None,
+    ):
+    s_t_fig = go.Figure()
+    for i, volume in enumerate(volumes):
+        s_t_fig.add_trace(
+            go.Scatter(
+                x=temperatures,
+                y=y[i],
+                mode='lines',
+                name=f'{volume:.2f} \u212B<sup>3</sup>'))
+    plot_format(s_t_fig,"Temperature (K)", f"{y_label}<sub>vib</sub> (eV/K/**atom**)")
+    
+    s_v_fig = go.Figure()
+    if selected_temperatures is None:
+        indices = np.linspace(0, len(temperatures) - 1, 5, dtype=int)
+        selected_temperatures = np.array([temperatures[j] for j in indices])
+    for i, temperature in enumerate(selected_temperatures):
+        s_v_fig.add_trace(
+            go.Scatter(
+                x=volumes,
+                y=y[:, i],
+                mode='lines',
+                name=f'{temperature:.2f} K'))
+    plot_format(s_v_fig,"Volume (\u212B<sup>3</sup>)", f"S<sub>vib</sub> (eV/K/**atom**)")
+    return s_t_fig, s_v_fig
+
+    
+
 
 def process_debye_gruneisen(
     config_path,

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -21,11 +21,20 @@ from dfttk.qha_yphon import plot_format
 A = 231.04
 BOLTZMANN = constants.physical_constants['Boltzmann constant in eV/K'][0]
 
-
+# check docstring bulk modulus derivative with respect to ____
 def gruneisen_parameter(
     bulk_modulus_prime: float,
     gruneisen_constant: float
 ) -> float:
+    """calculates the gruneisen parameter
+
+    Args:
+        bulk_modulus_prime: B_0', first derivative of the bulk modulus with respect to volume
+        gruneisen_constant: x, Should be between 2/3 (high temperature) and 1 (low temperature)
+
+    Returns:
+        float: gamma, the gruneisen parameter
+    """    
     return (1+bulk_modulus_prime)/2 - gruneisen_constant
 
 def debye_temperature(

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -245,7 +245,7 @@ def plot_debye(
     selected_temperatures: np.array | None = None,
     volume_decimals: int = 0,
     temperature_decimals: int = 0
-) -> go.Figure:
+) -> tuple[go.Figure, go.Figure]:
     """Plots the vibrational properties (S,F,C_V) as a function of temperature and volume
     
     Args:
@@ -259,7 +259,7 @@ def plot_debye(
         temperature_decimals: Number of decimals to display for the temperature in the plot
         
     Returns:
-        go.Figure: Plotly figure object
+        tuple[go.Figure, go.Figure]: Two plotly figures, one for the vibrational properties as a function of temperature and one for the vibrational properties as a function of volume
     """
     s_t_fig = go.Figure()
     for i, volume in enumerate(volumes):

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -43,7 +43,7 @@ def debye_temperature(
     
     return s * A * volume_0**(1/6) * (bulk_modulus/mass)**(1/2) * (volume_0/volume)**gru_param
 
-def debye_function(x_array: np.array, prec = 1e-6):
+def debye_function(x_array: np.array, prec = 1e-10):
     """series expansion of the debye function. valid for |𝑋|<2𝜋 and 𝑁≥1,
     comes from the expansion
     Gonzalez, I., Kondrashuk, I., Moll, V. H., & Vega, A. Analytic Expressions for Debye Functions and the Heat Capacity of a Solid. Mathematics, 10(10), 1745. https://doi.org/10.3390/math10101745
@@ -60,11 +60,11 @@ def debye_function(x_array: np.array, prec = 1e-6):
     Returns:
         _type_: _description_
     """
+    if not 0 < prec < 1:
+        raise ValueError("The precision must be between 0 and 1")
     result = np.zeros_like(x_array)
     bern_list = bernoulli(100) # 2*k must be less than 100
     for i, x in enumerate(x_array):
-        if not 0 < prec < 1:
-            raise ValueError("The precision must be between 0 and 1")
         term = 1 # ensures the while loop runs at least once
         k = 1
         if x >= 0.7*np.pi:

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -131,6 +131,8 @@ def vibrational_heat_capacity(temperature, theta):
 
 def process_debye_gruneisen(
     config_path,
+    volumes: np.array = None,
+    temperatures: np.array = np.linspace(10, 1000, 100),
     outcar_name: str = "OUTCAR.3static",
     oszicar_name: str = "OSZICAR.3static",
     contcar_name: str = "CONTCAR.3static",
@@ -161,11 +163,10 @@ def process_debye_gruneisen(
     gru_const = gruneisen_constant()
     gru_param = gruneisen_parameter(bulk_modulus_prime, gru_const)
     
-    volume_min = volume.min()
-    volume_max = volume.max()
-    
-    volumes = np.linspace(volume_min, volume_max, 200) # make volumes an input parameter
-    temperatures = np.linspace(1e-8, 200, 200)
+    if volumes is None:
+        volume_min = volume.min()
+        volume_max = volume.max() 
+        volumes = np.linspace(volume_min, volume_max, 10) # make volumes an input parameter
     
     total_mass = df['total_mass'][0]
     theta = debye_temperature(volumes, eos_parameters, total_mass, s, gru_param)

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -65,21 +65,32 @@ def debye_temperature(
     return s * A * volume_0**(1/6) * (bulk_modulus/mass)**(1/2) * (volume_0/volume)**gru_param
 
 def debye_function(x_array: np.array, prec = 1e-10, nth_bernoulli = 100):
-    """series expansion of the debye function. valid for |𝑋|<2𝜋 and 𝑁≥1,
-    comes from the expansion
+    """Calculates the debye function with n=3 using one of two series expansions. Valid for |𝑋|<2𝜋 and 𝑁≥1,
+    for -2pi < x < 0.7𝜋 the series
+    .. math::
+        1 - 3/8x + 3 \sum{k=1} \frac{B_{2k}}{(2k+3) \Gamma(2k+1)} * x^{2k}
+        
+    for x >= 0.7𝜋 the series
+    .. math::
+        \frac{\pi^4}{5x^3} - 3 \sum{k=1} \frac{1}{k} (1 + \frac{3}{kx} + \frac{6}{k^2x^2} + \frac{6}{k^3x^3}) * e^{-kx}
+        
+    See references,
     Gonzalez, I., Kondrashuk, I., Moll, V. H., & Vega, A. Analytic Expressions for Debye Functions and the Heat Capacity of a Solid. Mathematics, 10(10), 1745. https://doi.org/10.3390/math10101745
-    and Abramowitz, M. and Stegun, I.A. eds., 1968. Handbook of mathematical functions with formulas, graphs, and mathematical tables (Vol. 55). US Government printing office.
+    Abramowitz, M. and Stegun, I.A. eds., 1968. Handbook of mathematical functions with formulas, graphs, and mathematical tables (Vol. 55). US Government printing office.
+    Khishchenko, K., Analytic approximation of the Debye function, Mathematica Montisnigri (vol. 49), 2020.  https://doi.org/10.20948/MATHMONTIS-2020-49-8
 
     Args:
-        x: _description_
-        n: _description_. Defaults to 3.
-        order: the default is well within accuracy of floats and takes less than 0.0 seconds for n=3. Defaults to 30.
-
+        x_array: array of input values for the debye function
+        prec: Precission. Terminates the series expansion when the absolute value of the term is less than prec
+        nth_bernoulli: Determines the nth Bernoulli number to calculate. A list of bernoulli numbers is generated prior calculating the series expansion. There should be no reason to change this value under normal circumstances.
+        
     Raises:
-        ValueError: _description_
+        ValueError: If the precision is not between 0 and 1
+        ValueError: If x < -2𝜋
+        IndexError: If the bernoulli number at index 2k is not available. This indicates slow converges of the Debye function series expansion. If you wish to calculate values for x < -𝜋 convergence may be slow and you may need to increase nth_bernoulli.
 
     Returns:
-        _type_: _description_
+        np.array: The value of the debye function evaluated at each x in x_array
     """
     if not 0 < prec < 1:
         raise ValueError("The precision must be between 0 and 1")
@@ -101,7 +112,7 @@ def debye_function(x_array: np.array, prec = 1e-10, nth_bernoulli = 100):
                 try:
                     term = 3 * (bern_list[2*k]/((2*k+3)*gamma(2*k+1)) * x**(2*k))
                 except IndexError:
-                    raise IndexError(f"IndexError: the bernoulli number at index {2*k} is not available. This indicates slow converges of the Debye function series expansion. I hope you know what you are doing.")
+                    raise IndexError(f"IndexError: the bernoulli number at index {2*k} is not available. This indicates slow converges of the Debye function series expansion. If you wish to calculate values for x < -𝜋 convergence may be slow and you may need to increase nth_bernoulli.")
                 summation += term
                 k += 1
             result[i] = summation

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -304,9 +304,9 @@ def process_debye_gruneisen(
     n = df['number_of_atoms'][0]
 
     for i, volume in enumerate(volumes):
-        s_vib = vibrational_entropy(temperatures, theta[i])
-        f_vib = vibrational_helmholtz_energy(temperatures, theta[i])
-        cv_vib = vibrational_heat_capacity(temperatures, theta[i])
+        s_vib = vibrational_entropy(temperatures, theta[i], n)
+        f_vib = vibrational_helmholtz_energy(temperatures, theta[i], n)
+        cv_vib = vibrational_heat_capacity(temperatures, theta[i], n)
         s_vib_v_t[i, :] = s_vib
         f_vib_v_t[i, :] = f_vib 
         cv_vib_v_t[i, :] = cv_vib

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -126,6 +126,7 @@ def vibrational_heat_capacity(temperature, theta):
 def plot_debye(
     temperatures,
     volumes,
+    number_of_atoms,
     y,
     y_label,
     selected_temperatures = None,
@@ -140,7 +141,7 @@ def plot_debye(
                 y=y[i],
                 mode='lines',
                 name=f'{volume:.{volume_decimals}f} \u212B<sup>3</sup>'))
-    plot_format(s_t_fig,"Temperature (K)", f"{y_label}<sub>vib</sub> (eV/K/**atom**)")
+    plot_format(s_t_fig,"Temperature (K)", f"{y_label}<sub>vib</sub> (eV/K/{number_of_atoms} atoms)")
     
     s_v_fig = go.Figure()
     if selected_temperatures is None:
@@ -153,10 +154,8 @@ def plot_debye(
                 y=y[:, i],
                 mode='lines',
                 name=f'{temperature:.{temperature_decimals}f} K'))
-    plot_format(s_v_fig,"Volume (\u212B<sup>3</sup>)", f"S<sub>vib</sub> (eV/K/**atom**)")
+    plot_format(s_v_fig,"Volume (\u212B<sup>3</sup>)", f"S<sub>vib</sub> (eV/K/{number_of_atoms} atoms)")
     return s_t_fig, s_v_fig
-
-    
 
 
 def process_debye_gruneisen(
@@ -219,5 +218,7 @@ def process_debye_gruneisen(
         s_vib_v_t[i, :] = s_vib
         f_vib_v_t[i, :] = f_vib
         cv_vib_v_t[i, :] = cv_vib
-    return temperatures, volumes, s_vib_v_t, f_vib_v_t, cv_vib_v_t
+    n = df['number_of_atoms'][0]
+    
+    return temperatures, volumes, n, s_vib_v_t, f_vib_v_t, cv_vib_v_t
     

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -10,16 +10,14 @@ from dfttk import eos_fit
 from dfttk.data_extraction import extract_average_mass
 from dfttk.aggregate_extraction import extract_configuration_data
 from dfttk.qha_yphon import plot_format
+   
 
-
-
-# A is the ____ constant of th Debye-Gruneisen model in units of
-    # A = (8 * constants.pi**2)**(1/3)*constants.hbar/constants.k
-    
-
-# The definition of the Debye temperature is hbar/k_B * (6 * pi^2)^1/3 * N/V)
-# A = hbar/k_B * (6 * pi^2)^1/3
-A = 231.04 # K/(A*GPa/amu)^1/2
+# The definition of the Debye temperature is A * hbar/k_B * N/V) where A is
+# A = (6 * pi^2)^1/3 * hbar/k_B = 2.977*10^-11 s*K
+# converting to the of the eos_parameters,
+# A = (hbar/kb) * (6*math.pi**2)**(1/3) * (1*10**-10 m/Å)**(1/2) * (1*10**12 (g/(ms^2))/GPa)**(1/2) / ((1.66054*10**-24 g/u)**(1/2))
+# A = 231.0389521318254 K/(Å*GPa/u)^1/2
+A = 231.0389521318254
 BOLTZMANN_CONSTANT = constants.physical_constants['Boltzmann constant in eV/K'][0]
 
 # check docstring bulk modulus derivative with respect to ____

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -253,7 +253,7 @@ def process_debye_gruneisen(
     Args:
         config_path: Path to the config folder
         scaling_factor: s, Scaling factor for the Debye temperature
-        gruneisen_x: x, Gruneisen constant
+        gruneisen_x: x = 2/3 for high temperature case and x = 1 for low temperature case
         volumes: Array of volumes to evaluate the Debye thermal properties at
         temperatures: Array of temperatures to evaluate the Debye thermal properties at
         outcar_name: Name of the OUTCAR file

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -17,8 +17,7 @@ from dfttk.qha_yphon import plot_format
 
 # The definition of the Debye temperature is hbar/k_B * (6 * pi^2)^1/3 * N/V)
 # A = hbar/k_B * (6 * pi^2)^1/3
-# here A has units of K*s/(A*GPa*amu)^1/2 ??? check this ???
-A = 231.04
+A = 231.04 # K/(A*GPa*amu)^1/2
 BOLTZMANN = constants.physical_constants['Boltzmann constant in eV/K'][0]
 
 # check docstring bulk modulus derivative with respect to ____
@@ -345,7 +344,7 @@ def process_debye_gruneisen(
         volumes = np.linspace(volume_min, volume_max, 10) # make volumes an input parameter
     
     total_mass = df['total_mass'][0]
-    theta = debye_temperature(volumes, eos_parameters, total_mass, s, gru_param)
+    theta = debye_temperature(volumes, eos_parameters, total_mass, gru_param, s)
     
     s_vib_v_t = np.zeros((len(volumes), len(temperatures)))
     f_vib_v_t = np.zeros((len(volumes), len(temperatures)))

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -15,7 +15,7 @@ from dfttk.data_extraction import extract_atomic_masses
 A = 231.04
 BOLTZMANN = constants.physical_constants['Boltzmann constant in eV/K'][0]
 
-def scaling_factor(temperature):
+def scaling_factor():
     s = 0.75
 
 def gruneisen_constant():

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -58,7 +58,8 @@ def debye_function(x: float, n: int = 3, order: int = 30):
     
 
     if x > 1.5*np.pi:
-        return np.exp(-k*x)((x**n)/k + )
+        return
+        # return np.exp(-k*x)((x**n)/k + )
     if x <= 1.5*np.pi:
         if order > 2:
             bern_list = bernoulli(2*(order-2))

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -125,59 +125,6 @@ def debye_function(
     return result
 
         
-def debye_function_derivative(
-    x_array: np.array,
-    prec: float =1e-12,
-    nth_bernoulli: int = 100
-) -> np.array:
-    """Calculates the derivative of the debye function with n=3 using one of two series expansions. Valid for |𝑋|<2𝜋 and 𝑁≥1,
-    for -2pi < x < 0.7𝜋,
-    .. math::
-        D'(x) = -3/8 + 3 \sum{k=1} \frac{B_{2k}}{(2k+3) \Gamma(2k+1)} * 2kx^{2k-1}
-    
-    for x >= 0.7𝜋,
-    .. math::
-        D'(x) = -3 \frac{\pi**4-3}{5x**4} + -3 \sum{k=1} \exp(-kx) (1 + 3/(kx) + 9/(k**2x**2) + 18/(k**3x**3) + 18/(k**4x**4))
-        
-    See references,
-    Gonzalez, I., Kondrashuk, I., Moll, V. H., & Vega, A. Analytic Expressions for Debye Functions and the Heat Capacity of a Solid. Mathematics, 10(10), 1745. https://doi.org/10.3390/math10101745
-    Abramowitz, M. and Stegun, I.A. eds., 1968. Handbook of mathematical functions with formulas, graphs, and mathematical tables (Vol. 55). US Government printing office.
-    Khishchenko, K., Analytic approximation of the Debye function, Mathematica Montisnigri (vol. 49), 2020.  https://doi.org/10.20948/MATHMONTIS-2020-49-8
-
-    Args:
-        x_array: array of input values for the debye function derivative
-        prec: Precission. Terminates the series expansion when the absolute value of the term is less than prec
-        nth_bernoulli: Determines the nth Bernoulli number to calculate. A list of bernoulli numbers is generated prior calculating the series expansion. There should be no reason to change this value under normal circumstances.
-    """
-    if not 0 < prec < 1:
-        raise ValueError("The precision must be between 0 and 1")
-    result = np.zeros_like(x_array)
-    bern_list = bernoulli(nth_bernoulli) # 2*k must be less than 100
-    for i, x in enumerate(x_array):
-        term = 1 # ensures the while loop runs at least once
-        k = 1
-        if x >= 0.7*np.pi:
-            summation = -3*np.pi**4/(5*x**4)
-            while abs(term) > prec:
-                term = -3*(-np.exp(-k*x)*(1 + 3/(k*x) + 9/(k**2*x**2) + 18/(k**3*x**3) + 18/(k**4*x**4)))
-                summation += term
-                k += 1
-            result[i] = summation
-        elif -2*np.pi < x < 0.7*np.pi:
-            summation = -3/8
-            term = 1 # ensures the while loop runs at least once
-            while abs(term) > prec:
-                try:
-                    term = 3*(bern_list[2*k]/((2*k+3)*gamma(2*k+1)) * 2*k*x**(2*k-1))
-                except IndexError:
-                    raise IndexError(f"IndexError: the bernoulli number at index {2*k} is not available. This indicates slow converges of the Debye function derivative series expansion. I hope you know what you are doing.")
-                summation += term
-                k += 1
-            result[i] = summation
-        else:
-            raise ValueError("The debye function derivative series expansions used are only valid for x > -2𝜋")
-    return result
-
 def vibrational_energy(temperature: float, theta: float, number_of_atoms) -> float: 
     """Evaluates the debye function at x = theta/temperature then calculates the vibrational energy in eV.
 

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -282,7 +282,7 @@ def plot_debye(
                 y=y[:, i],
                 mode='lines',
                 name=f'{temperature:.{temperature_decimals}f} K'))
-    plot_format(s_v_fig,"Volume (\u212B<sup>3</sup>)", f"S<sub>vib</sub> (eV/K/{number_of_atoms} atoms)")
+    plot_format(s_v_fig,"Volume (\u212B<sup>3</sup>)", f"{y_label}<sub>vib</sub> (eV/K/{number_of_atoms} atoms)")
     return s_t_fig, s_v_fig
 
 

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -17,7 +17,7 @@ from dfttk.qha_yphon import plot_format
 
 # The definition of the Debye temperature is hbar/k_B * (6 * pi^2)^1/3 * N/V)
 # A = hbar/k_B * (6 * pi^2)^1/3
-A = 231.04 # K/(A*GPa*amu)^1/2
+A = 231.04 # K/(A*GPa/amu)^1/2
 BOLTZMANN = constants.physical_constants['Boltzmann constant in eV/K'][0]
 
 # check docstring bulk modulus derivative with respect to ____
@@ -60,6 +60,7 @@ def debye_temperature(
     energy_0 = eos_parameters[1]
     bulk_modulus = eos_parameters[2]
     bulk_modulus_prime = eos_parameters[3]
+    bulk_modulus_2prime = eos_parameters[4]
     
     return s * A * volume_0**(1/6) * (bulk_modulus/mass)**(1/2) * (volume_0/volume)**gru_param
 
@@ -344,7 +345,10 @@ def process_debye_gruneisen(
         volumes = np.linspace(volume_min, volume_max, 10) # make volumes an input parameter
     
     total_mass = df['total_mass'][0]
-    theta = debye_temperature(volumes, eos_parameters, total_mass, gru_param, s)
+    number_of_atoms = df['number_of_atoms'][0]
+    atomic_mass = total_mass/number_of_atoms # this needs to be corrected. arithmetic mean is no good. need geometric or log
+    
+    theta = debye_temperature(volumes, eos_parameters, atomic_mass, gru_param, s)
     
     s_vib_v_t = np.zeros((len(volumes), len(temperatures)))
     f_vib_v_t = np.zeros((len(volumes), len(temperatures)))

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -72,11 +72,11 @@ def debye_function(
     """Calculates the debye function with n=3 using one of two series expansions. Valid for |𝑋|<2𝜋 and 𝑁≥1,
     for -2pi < x < 0.7𝜋
     .. math::
-       D(x) = 1 - 3/8x + 3 \sum{k=1} \frac{B_{2k}}{(2k+3) \Gamma(2k+1)} * x^{2k}
+       D(x) = 1 - 3/8x + 3 \\sum{k=1} \\frac{B_{2k}}{(2k+3) \\Gamma(2k+1)} * x^{2k}
         
     for x >= 0.7𝜋 the series
     .. math::
-       D(x) = \frac{\pi^4}{5x^3} - 3 \sum{k=1} \frac{1}{k} (1 + \frac{3}{kx} + \frac{6}{k^2x^2} + \frac{6}{k^3x^3}) * e^{-kx}
+       D(x) = \\frac{\\pi^4}{5x^3} - 3 \\sum{k=1} \\frac{1}{k} (1 + \\frac{3}{kx} + \\frac{6}{k^2x^2} + \\frac{6}{k^3x^3}) * e^{-kx}
         
     See references,
     Gonzalez, I., Kondrashuk, I., Moll, V. H., & Vega, A. Analytic Expressions for Debye Functions and the Heat Capacity of a Solid. Mathematics, 10(10), 1745. https://doi.org/10.3390/math10101745

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -1,13 +1,12 @@
-import os
 import numpy as np
 import plotly.graph_objects as go
+
 from scipy import constants
 from scipy.special import bernoulli
 from scipy.special import gamma
-from pymatgen.io.vasp.outputs import Poscar
+
 from dfttk import eos_fit
 from dfttk.aggregate_extraction import extract_configuration_data
-from dfttk.data_extraction import extract_atomic_masses
 from dfttk.qha_yphon import plot_format
 
 

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -222,6 +222,7 @@ def vibrational_helmholtz_energy(temperature: float, theta:float) -> float:
     debye_value = debye_function(x)
     return 9/8*BOLTZMANN*theta + BOLTZMANN*temperature*(3*np.log(1-np.exp(-x)) - debye_value)
 
+# TODO: fix. this equation is wrong
 def vibrational_heat_capacity(temperature: float, theta: float) -> float:
     """Evaluates the debye function and its derivative at x = theta/temperature then
     calculates the vibrational heat capacity in eV/K.
@@ -352,7 +353,7 @@ def process_debye_gruneisen(
     
     s_vib_v_t = np.zeros((len(volumes), len(temperatures)))
     f_vib_v_t = np.zeros((len(volumes), len(temperatures)))
-    cv_vib_v_t = np.zeros((len(volumes), len(temperatures)))
+    cv_vib_v_t = np.zeros((len(volumes), len(temperatures)-1))
     n = df['number_of_atoms'][0]
 
     for i, volume in enumerate(volumes):
@@ -360,11 +361,11 @@ def process_debye_gruneisen(
         debye_value = debye_function(x)
         s_vib = vibrational_entropy(temperatures, theta[i]) * n
         f_vib = vibrational_helmholtz_energy(temperatures, theta[i]) * n
-        cv_vib = vibrational_heat_capacity(temperatures, theta[i]) * n
+        # cv_vib = vibrational_heat_capacity(temperatures, theta[i]) * n
         # Compute the differences between successive elements
         d_s_vib = np.array([k - j for j, k in zip(s_vib[:-1], s_vib[1:])])
         dt = np.array([k - j for j, k in zip(temperatures[:-1], temperatures[1:])])
-        c_p = temperatures[:-1] * d_s_vib / dt # this is incorrect because it is done at constant volume
+        cv_vib = temperatures[:-1] * d_s_vib / dt 
         s_vib_v_t[i, :] = s_vib
         f_vib_v_t[i, :] = f_vib
         cv_vib_v_t[i, :] = cv_vib

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -72,18 +72,18 @@ def debye_function(
     nth_bernoulli: int = 100
 ) -> np.array:
     """Calculates the debye function with n=3 using one of two series expansions. Valid for |𝑋|<2𝜋 and 𝑁≥1,
-    for -2pi < x < 0.7𝜋
+    for -2pi < x < 0.7𝜋. 
     .. math::
-       D(x) = 1 - 3/8x + 3 \\sum{k=1} \\frac{B_{2k}}{(2k+3) \\Gamma(2k+1)} * x^{2k}
+       D(x) = 1 - 3/8x + 3 \\sum{k=1} \\frac{B_{2k}}{(2k+3) \\Gamma(2k+1)} * x^{2k} 
         
     for x >= 0.7𝜋 the series
     .. math::
        D(x) = \\frac{\\pi^4}{5x^3} - 3 \\sum{k=1} \\frac{1}{k} (1 + \\frac{3}{kx} + \\frac{6}{k^2x^2} + \\frac{6}{k^3x^3}) * e^{-kx}
         
     See references,
-    Gonzalez, I., Kondrashuk, I., Moll, V. H., & Vega, A. Analytic Expressions for Debye Functions and the Heat Capacity of a Solid. Mathematics, 10(10), 1745. https://doi.org/10.3390/math10101745
+    Eq. (4) of Gonzalez, I., Kondrashuk, I., Moll, V. H., & Vega, A. Analytic Expressions for Debye Functions and the Heat Capacity of a Solid. Mathematics, 10(10), 1745. https://doi.org/10.3390/math10101745
     Abramowitz, M. and Stegun, I.A. eds., 1968. Handbook of mathematical functions with formulas, graphs, and mathematical tables (Vol. 55). US Government printing office.
-    Khishchenko, K., Analytic approximation of the Debye function, Mathematica Montisnigri (vol. 49), 2020.  https://doi.org/10.20948/MATHMONTIS-2020-49-8
+    Eq. (17) of Khishchenko, K., Analytic approximation of the Debye function, Mathematica Montisnigri (vol. 49), 2020.  https://doi.org/10.20948/MATHMONTIS-2020-49-8
 
     Args:
         x_array: array of input values for the debye function

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -64,15 +64,19 @@ def debye_temperature(
     
     return s * A * volume_0**(1/6) * (bulk_modulus/mass)**(1/2) * (volume_0/volume)**gru_param
 
-def debye_function(x_array: np.array, prec = 1e-10, nth_bernoulli = 100):
+def debye_function(
+    x_array: np.array,
+    prec: float = 1e-10,
+    nth_bernoulli: int = 100
+) -> np.array:
     """Calculates the debye function with n=3 using one of two series expansions. Valid for |𝑋|<2𝜋 and 𝑁≥1,
-    for -2pi < x < 0.7𝜋 the series
+    for -2pi < x < 0.7𝜋
     .. math::
-        1 - 3/8x + 3 \sum{k=1} \frac{B_{2k}}{(2k+3) \Gamma(2k+1)} * x^{2k}
+       D(x) = 1 - 3/8x + 3 \sum{k=1} \frac{B_{2k}}{(2k+3) \Gamma(2k+1)} * x^{2k}
         
     for x >= 0.7𝜋 the series
     .. math::
-        \frac{\pi^4}{5x^3} - 3 \sum{k=1} \frac{1}{k} (1 + \frac{3}{kx} + \frac{6}{k^2x^2} + \frac{6}{k^3x^3}) * e^{-kx}
+       D(x) = \frac{\pi^4}{5x^3} - 3 \sum{k=1} \frac{1}{k} (1 + \frac{3}{kx} + \frac{6}{k^2x^2} + \frac{6}{k^3x^3}) * e^{-kx}
         
     See references,
     Gonzalez, I., Kondrashuk, I., Moll, V. H., & Vega, A. Analytic Expressions for Debye Functions and the Heat Capacity of a Solid. Mathematics, 10(10), 1745. https://doi.org/10.3390/math10101745
@@ -121,10 +125,29 @@ def debye_function(x_array: np.array, prec = 1e-10, nth_bernoulli = 100):
     return result
 
         
-def debye_function_derivative(x_array, prec=1e-10, nth_bernoulli=100):
-    """series expansion of the derivative of the debye function. valid for |𝑋|<2𝜋 and 𝑁≥1, comes from the expansion
+def debye_function_derivative(
+    x_array: np.array,
+    prec: float =1e-10,
+    nth_bernoulli: int = 100
+) -> np.array:
+    """Calculates the derivative of the debye function with n=3 using one of two series expansions. Valid for |𝑋|<2𝜋 and 𝑁≥1,
+    for -2pi < x < 0.7𝜋,
+    .. math::
+        D'(x) = -3/8 + 3 \sum{k=1} \frac{B_{2k}}{(2k+3) \Gamma(2k+1)} * 2kx^{2k-1}
+    
+    for x >= 0.7𝜋,
+    .. math::
+        D'(x) = -3 \frac{\pi**4-3}{5x**4} + -3 \sum{k=1} \exp(-kx) (1 + 3/(kx) + 9/(k**2x**2) + 18/(k**3x**3) + 18/(k**4x**4))
+        
+    See references,
     Gonzalez, I., Kondrashuk, I., Moll, V. H., & Vega, A. Analytic Expressions for Debye Functions and the Heat Capacity of a Solid. Mathematics, 10(10), 1745. https://doi.org/10.3390/math10101745
-    and Abramowitz, M. and Stegun, I.A. eds., 1968. Handbook of mathematical functions with formulas, graphs, and mathematical tables (Vol. 55). US Government printing office.
+    Abramowitz, M. and Stegun, I.A. eds., 1968. Handbook of mathematical functions with formulas, graphs, and mathematical tables (Vol. 55). US Government printing office.
+    Khishchenko, K., Analytic approximation of the Debye function, Mathematica Montisnigri (vol. 49), 2020.  https://doi.org/10.20948/MATHMONTIS-2020-49-8
+
+    Args:
+        x_array: array of input values for the debye function derivative
+        prec: Precission. Terminates the series expansion when the absolute value of the term is less than prec
+        nth_bernoulli: Determines the nth Bernoulli number to calculate. A list of bernoulli numbers is generated prior calculating the series expansion. There should be no reason to change this value under normal circumstances.
     """
     if not 0 < prec < 1:
         raise ValueError("The precision must be between 0 and 1")
@@ -155,11 +178,20 @@ def debye_function_derivative(x_array, prec=1e-10, nth_bernoulli=100):
             raise ValueError("The debye function derivative series expansions used are only valid for x > -2𝜋")
     return result
 
-def vibrational_energy(temperature, theta):
+def vibrational_energy(temperature: float, theta: float) -> float: 
+    """Evaluates the debye function at x = theta/temperature then calculates the vibrational energy in eV.
+
+    Args:
+        temperature : Temperature in Kelvin
+        theta: Debye temperature in Kelvin
+
+    Returns:
+        float: Vibrational energy in eV
+    """    
     debye_value = debye_function(theta/temperature)
     return 3 * BOLTZMANN * temperature * debye_value + 9/8 * BOLTZMANN * theta
 
-def vibrational_entropy(temperature, theta):
+def vibrational_entropy(temperature: float, theta: float):
     x = theta/temperature
     debye_value = debye_function(x)
     return 3*BOLTZMANN*(4/3*debye_value-np.log(1-np.exp(-x)))

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -20,7 +20,7 @@ from dfttk.qha_yphon import plot_format
 # The definition of the Debye temperature is hbar/k_B * (6 * pi^2)^1/3 * N/V)
 # A = hbar/k_B * (6 * pi^2)^1/3
 A = 231.04 # K/(A*GPa/amu)^1/2
-BOLTZMANN = constants.physical_constants['Boltzmann constant in eV/K'][0]
+BOLTZMANN_CONSTANT = constants.physical_constants['Boltzmann constant in eV/K'][0]
 
 # check docstring bulk modulus derivative with respect to ____
 def gruneisen_parameter(
@@ -139,7 +139,7 @@ def vibrational_energy(temperature: float, theta: float, number_of_atoms) -> flo
         float: Vibrational energy in eV
     """    
     debye_value = debye_function(theta/temperature)
-    return number_of_atoms * BOLTZMANN * (3 * temperature * debye_value + 9/8 * theta)
+    return number_of_atoms * BOLTZMANN_CONSTANT * (3 * temperature * debye_value + 9/8 * theta)
 
 def vibrational_entropy(temperature: float, theta: float, number_of_atoms) -> float:
     """Evaluates the debye function at x = theta/temperature then
@@ -156,7 +156,7 @@ def vibrational_entropy(temperature: float, theta: float, number_of_atoms) -> fl
     """
     x = theta/temperature
     debye_value = debye_function(x)
-    return 3* number_of_atoms *BOLTZMANN*(4/3*debye_value-np.log(1-np.exp(-x)))
+    return 3* number_of_atoms *BOLTZMANN_CONSTANT*(4/3*debye_value-np.log(1-np.exp(-x)))
 
 def vibrational_helmholtz_energy(temperature: float, theta:float, number_of_atoms) -> float:
     """Evaluates the debye function at x = theta/temperature then
@@ -172,7 +172,7 @@ def vibrational_helmholtz_energy(temperature: float, theta:float, number_of_atom
     """
     x = theta/temperature
     debye_value = debye_function(x)
-    return number_of_atoms * (9/8*BOLTZMANN*theta + BOLTZMANN*temperature*(3*np.log(1-np.exp(-x)) - debye_value))
+    return number_of_atoms * (9/8*BOLTZMANN_CONSTANT*theta + BOLTZMANN_CONSTANT*temperature*(3*np.log(1-np.exp(-x)) - debye_value))
 
 def vibrational_heat_capacity(temperature: float, theta: float, number_of_atoms) -> float:
     """Evaluates the debye function and its derivative at x = theta/temperature then
@@ -188,7 +188,7 @@ def vibrational_heat_capacity(temperature: float, theta: float, number_of_atoms)
     """
     x = theta/temperature
     debye_value = debye_function(x)
-    return  3*number_of_atoms*BOLTZMANN*(4*debye_value - 3*x/(np.exp(x)-1))
+    return  3*number_of_atoms*BOLTZMANN_CONSTANT*(4*debye_value - 3*x/(np.exp(x)-1))
 
 def plot_debye(
     temperatures: np.array,

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -353,13 +353,14 @@ def process_debye_gruneisen(
     s_vib_v_t = np.zeros((len(volumes), len(temperatures)))
     f_vib_v_t = np.zeros((len(volumes), len(temperatures)))
     cv_vib_v_t = np.zeros((len(volumes), len(temperatures)))
-    
+    n = df['number_of_atoms'][0]
+
     for i, volume in enumerate(volumes):
         x = theta[i]/temperatures
         debye_value = debye_function(x)
-        s_vib = vibrational_entropy(temperatures, theta[i])
-        f_vib = vibrational_helmholtz_energy(temperatures, theta[i])
-        cv_vib = vibrational_heat_capacity(temperatures, theta[i])
+        s_vib = vibrational_entropy(temperatures, theta[i]) * n
+        f_vib = vibrational_helmholtz_energy(temperatures, theta[i]) * n
+        cv_vib = vibrational_heat_capacity(temperatures, theta[i]) * n
         # Compute the differences between successive elements
         d_s_vib = np.array([k - j for j, k in zip(s_vib[:-1], s_vib[1:])])
         dt = np.array([k - j for j, k in zip(temperatures[:-1], temperatures[1:])])
@@ -367,7 +368,7 @@ def process_debye_gruneisen(
         s_vib_v_t[i, :] = s_vib
         f_vib_v_t[i, :] = f_vib
         cv_vib_v_t[i, :] = cv_vib
-    n = df['number_of_atoms'][0]
+    
     
     return temperatures, volumes, n, s_vib_v_t, f_vib_v_t, cv_vib_v_t
     

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -106,22 +106,22 @@ def debye_function(
         term = 1 # ensures the while loop runs at least once
         k = 1
         if x >= 0.7*np.pi:
-            summation = np.pi**4/(5*x**3)
+            debye_value = np.pi**4/(5*x**3)
             while abs(term) > prec:
                 term = -3*(1/k*(1 + 3/(k*x) + 6/(k**2*x**2) + 6/(k**3*x**3))*np.exp(-k*x))
-                summation += term
+                debye_value += term
                 k += 1
-            result[i] = summation
+            result[i] = debye_value
         elif -2*np.pi < x < 0.7*np.pi:
-            summation = 1 - 3/8*x
+            debye_value = 1 - 3/8*x
             while abs(term) > prec:
                 try:
                     term = 3 * (bern_list[2*k]/((2*k+3)*gamma(2*k+1)) * x**(2*k))
                 except IndexError:
                     raise IndexError(f"IndexError: the bernoulli number at index {2*k} is not available. This indicates slow converges of the Debye function series expansion. If you wish to calculate values for x < -𝜋 convergence may be slow and you may need to increase nth_bernoulli.")
-                summation += term
+                debye_value += term
                 k += 1
-            result[i] = summation
+            result[i] = debye_value
         else:
             raise ValueError("The debye function series expansions used are only valid for x > -2𝜋")
     return result

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -178,7 +178,7 @@ def debye_function_derivative(
             raise ValueError("The debye function derivative series expansions used are only valid for x > -2𝜋")
     return result
 
-def vibrational_energy(temperature: float, theta: float) -> float: 
+def vibrational_energy(temperature: float, theta: float, number_of_atoms) -> float: 
     """Evaluates the debye function at x = theta/temperature then calculates the vibrational energy in eV.
 
     Args:
@@ -189,9 +189,9 @@ def vibrational_energy(temperature: float, theta: float) -> float:
         float: Vibrational energy in eV
     """    
     debye_value = debye_function(theta/temperature)
-    return 3 * BOLTZMANN * temperature * debye_value + 9/8 * BOLTZMANN * theta
+    return number_of_atoms * BOLTZMANN * (3 * temperature * debye_value + 9/8 * theta)
 
-def vibrational_entropy(temperature: float, theta: float) -> float:
+def vibrational_entropy(temperature: float, theta: float, number_of_atoms) -> float:
     """Evaluates the debye function at x = theta/temperature then
     calculates the vibrational entropy in eV/K.
     
@@ -205,9 +205,9 @@ def vibrational_entropy(temperature: float, theta: float) -> float:
     """
     x = theta/temperature
     debye_value = debye_function(x)
-    return 3*BOLTZMANN*(4/3*debye_value-np.log(1-np.exp(-x)))
+    return 3* number_of_atoms *BOLTZMANN*(4/3*debye_value-np.log(1-np.exp(-x)))
 
-def vibrational_helmholtz_energy(temperature: float, theta:float) -> float:
+def vibrational_helmholtz_energy(temperature: float, theta:float, number_of_atoms) -> float:
     """Evaluates the debye function at x = theta/temperature then
     calculates the vibrational Helmholtz energy in eV.
     
@@ -220,9 +220,9 @@ def vibrational_helmholtz_energy(temperature: float, theta:float) -> float:
     """
     x = theta/temperature
     debye_value = debye_function(x)
-    return 9/8*BOLTZMANN*theta + BOLTZMANN*temperature*(3*np.log(1-np.exp(-x)) - debye_value)
+    return number_of_atoms * (9/8*BOLTZMANN*theta + BOLTZMANN*temperature*(3*np.log(1-np.exp(-x)) - debye_value))
 
-def vibrational_heat_capacity(temperature: float, theta: float) -> float:
+def vibrational_heat_capacity(temperature: float, theta: float, number_of_atoms) -> float:
     """Evaluates the debye function and its derivative at x = theta/temperature then
     calculates the vibrational heat capacity in eV/K.
     
@@ -235,7 +235,7 @@ def vibrational_heat_capacity(temperature: float, theta: float) -> float:
     """
     x = theta/temperature
     debye_value = debye_function(x)
-    return  3*BOLTZMANN*(4*debye_value - 3*x/(np.exp(x)-1))
+    return  3*number_of_atoms*BOLTZMANN*(4*debye_value - 3*x/(np.exp(x)-1))
 
 def plot_debye(
     temperatures: np.array,
@@ -357,15 +357,9 @@ def process_debye_gruneisen(
     n = df['number_of_atoms'][0]
 
     for i, volume in enumerate(volumes):
-        x = theta[i]/temperatures
-        debye_value = debye_function(x)
-        s_vib = vibrational_entropy(temperatures, theta[i]) * n
-        f_vib = vibrational_helmholtz_energy(temperatures, theta[i]) * n
-        cv_vib = vibrational_heat_capacity(temperatures, theta[i]) * n
-        # # Compute the differences between successive elements
-        # d_s_vib = np.array([k - j for j, k in zip(s_vib[:-1], s_vib[1:])])
-        # dt = np.array([k - j for j, k in zip(temperatures[:-1], temperatures[1:])])
-        # cv_vib = temperatures[:-1] * d_s_vib / dt 
+        s_vib = vibrational_entropy(temperatures, theta[i])
+        f_vib = vibrational_helmholtz_energy(temperatures, theta[i])
+        cv_vib = vibrational_heat_capacity(temperatures, theta[i])
         s_vib_v_t[i, :] = s_vib
         f_vib_v_t[i, :] = f_vib 
         cv_vib_v_t[i, :] = cv_vib

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -17,14 +17,6 @@ from dfttk.qha_yphon import plot_format
 A = 231.04
 BOLTZMANN = constants.physical_constants['Boltzmann constant in eV/K'][0]
 
-def scaling_factor(poisson_ratio):
-    term1 = (4 * np.sqrt(2) * ((1 + poisson_ratio) / (1 - 2 * poisson_ratio)) ** (3 / 2))
-    term2 = ((1 + poisson_ratio) / (1 - poisson_ratio)) ** (3 / 2)
-    result = 3 ** (5 / 6) * (term1 + term2) ** (-1 / 3)
-    return result
-
-def gruneisen_constant():
-    return 1.0
 
 def gruneisen_parameter(bulk_modulus_prime, gruneisen_constant):
     return (1+bulk_modulus_prime)/2 - gruneisen_constant
@@ -169,6 +161,8 @@ def plot_debye(
 
 def process_debye_gruneisen(
     config_path,
+    scaling_factor: float = 0.617,
+    gruneisen_constant: float = 1,
     volumes: np.array = None,
     temperatures: np.array = np.linspace(10, 1000, 100),
     outcar_name: str = "OUTCAR.3static",
@@ -196,9 +190,8 @@ def process_debye_gruneisen(
     _, eos_parameters, _, _, _ = eos_fitting(volume, energy)
     volume_0, energy_0, bulk_modulus, bulk_modulus_prime, bulk_modulus_2prime = eos_parameters
     
-    # s = scaling_factor()
-    s = 0.617 # for now, this is a constant
-    gru_const = gruneisen_constant()
+    s = scaling_factor
+    gru_const = gruneisen_constant
     gru_param = gruneisen_parameter(bulk_modulus_prime, gru_const)
     
     if volumes is None:

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -1,7 +1,12 @@
+import os
+import numpy as np
 from scipy import constants
 from scipy.special import bernoulli
 from scipy.special import gamma
 from dfttk import eos_fit
+from dfttk.data_extraction import extract_configuration_data
+from dfttk.data_extraction import extract_mass
+
 
 
 # A is the ____ constant of th Debye-Gruneisen model
@@ -16,29 +21,94 @@ def gruneisen_constant():
 def gruneisen_parameter(bulk_modulus_prime, gruneisen_constant):
     return (1+bulk_modulus_prime)/2 - gruneisen_constant
 
-def debye_temperature(volume, eos_parameters,
+def debye_temperature(
+    volume,
+    eos_parameters,
     mass,
     scaling_factor,
-    gruneisen_constant):
+    gru_param
+):
     s = scaling_factor
     volume_0 = eos_parameters[0]
     energy_0 = eos_parameters[1]
     bulk_modulus = eos_parameters[2]
     bulk_modulus_prime = eos_parameters[3]
     
-    gru_param = gruneisen_parameter(bulk_modulus_prime, gruneisen_constant)
-    
     return s * A * volume_0**(1/6) * (bulk_modulus/mass)**(1/2) * (volume_0/volume)**gru_param
 
 def debye_function(x, n=3, order=5):
     """series expansion of the debye function. valid for |𝑋|<2𝜋 and 𝑁≥1, comes from the expansion
     Gonzalez, I., Kondrashuk, I., Moll, V. H., & Vega, A. Analytic Expressions for Debye Functions and the Heat Capacity of a Solid. Mathematics, 10(10), 1745. https://doi.org/10.3390/math10101745
+    and Abramowitz, M. and Stegun, I.A. eds., 1968. Handbook of mathematical functions with formulas, graphs, and mathematical tables (Vol. 55). US Government printing office.
+    """
+
+    summation = sum(bernoulli(2*k)/((2*k+n)*gamma(2*k+1)) * x**(2*k) for k in range(1, order-2))
+    return 1 - n/(2(n+1))*x + n*summation
+
+def debye_function_derivative(x, n=3, order=5):
+    """series expansion of the derivative of the debye function. valid for |𝑋|<2𝜋 and 𝑁≥1, comes from the expansion
+    Gonzalez, I., Kondrashuk, I., Moll, V. H., & Vega, A. Analytic Expressions for Debye Functions and the Heat Capacity of a Solid. Mathematics, 10(10), 1745. https://doi.org/10.3390/math10101745
+    and Abramowitz, M. and Stegun, I.A. eds., 1968. Handbook of mathematical functions with formulas, graphs, and mathematical tables (Vol. 55). US Government printing office.
     """
     
-    for k in range(1, order-2):
-        summation = bernoulli(2*k)/((2*k+n)*gamma(2*k+1)) * x**(2*k)
+    summation = sum(bernoulli(2*k)/((2*k+n)*gamma(2*k+1)) * 2*k*x**(2*k-1) for k in range(1, order-2))
+    return -n/(2*(n+1)) + n*summation
         
-    return 1 - n/(2(n+1)*x) + n*summation
+    return -n/((2*n+1)) + n*summation
 
-def debye_gruneisen_():
-    pass
+def vibrational_energy(temperature, theta):
+    debye_value = debye_function(theta/temperature)
+    return 3 * constants.k * temperature * debye_value + 9/8 * constants.k * theta
+
+def vibrational_entropy(temperature, theta):
+    x = theta/temperature
+    debye_value = debye_function(x)
+    return 3*constants.k*(4/3*debye_value-np.log(1-np.exp(-x)))
+
+def vibrational_helmholtz_energy(temperature, theta):
+    x = theta/temperature
+    debye_value = debye_function(x)
+    return 9/8*constants.k*theta + constants.k*temperature*(3*np.log(1-np.exp(-x)) - debye_value)
+
+def vibrational_heat_capacity(temperature, theta):
+    x = theta/temperature
+    return 3*constants.k*temperature*debye_function_derivative(x) + debye_function(x)
+
+def debye_gruneisen(
+    config_path,
+    outcar_name: str = "OUTCAR.3static",
+    oszicar_name: str = "OSZICAR.3static",
+    contcar_name: str = "CONTCAR.3static",
+    collect_mag_data: bool = False,
+    magmom_tolerance: float = 1e-12,
+    total_magnetic_moment_tolerance: float = 1e-12,
+    eos_fitting = eos_fit.BM4
+):
+    # extract the volume and energy from the ev_curve_series
+    df = extract_configuration_data(
+        path = config_path,
+        outcar_name = outcar_name,
+        oszicar_name = oszicar_name,
+        contcar_name = contcar_name,
+        collect_mag_data = collect_mag_data,
+        magmom_tolerance = magmom_tolerance,
+        total_magnetic_moment_tolerance = total_magnetic_moment_tolerance
+    )
+    
+    # fit the equation of state
+    _, eos_parameters, _, _, _ = eos_fitting(df)
+    volume_0, energy_0, bulk_modulus, bulk_modulus_prime, bulk_modulus_2prime = eos_parameters
+    
+    
+    # extract the mass of each atom from the OUTCAR file
+    mass = extract_mass(os.path.join(config_path, outcar_name))
+    
+    s = scaling_factor()
+    gru_const = gruneisen_constant()
+    gru_param = gruneisen_parameter(bulk_modulus_prime, gru_const)
+    
+    theta = debye_temperature(volume, eos_parameters, mass, s, gru_param)
+    x=theta/temperature
+    debye_value = debye_function(x)
+    
+    

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -137,6 +137,8 @@ def plot_debye(
     y,
     y_label,
     selected_temperatures = None,
+    volume_decimals = 0,
+    temperature_decimals = 0
     ):
     s_t_fig = go.Figure()
     for i, volume in enumerate(volumes):
@@ -145,7 +147,7 @@ def plot_debye(
                 x=temperatures,
                 y=y[i],
                 mode='lines',
-                name=f'{volume:.2f} \u212B<sup>3</sup>'))
+                name=f'{volume:.{volume_decimals}f} \u212B<sup>3</sup>'))
     plot_format(s_t_fig,"Temperature (K)", f"{y_label}<sub>vib</sub> (eV/K/**atom**)")
     
     s_v_fig = go.Figure()
@@ -158,7 +160,7 @@ def plot_debye(
                 x=volumes,
                 y=y[:, i],
                 mode='lines',
-                name=f'{temperature:.2f} K'))
+                name=f'{temperature:.{temperature_decimals}f} K'))
     plot_format(s_v_fig,"Volume (\u212B<sup>3</sup>)", f"S<sub>vib</sub> (eV/K/**atom**)")
     return s_t_fig, s_v_fig
 

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -290,7 +290,7 @@ def process_debye_gruneisen(
     if volumes is None:
         volume_min = volume.min()
         volume_max = volume.max() 
-        volumes = np.linspace(volume_min, volume_max, 10) # make volumes an input parameter
+        volumes = np.linspace(volume_min, volume_max, 10) 
     
     total_mass = df['total_mass'][0]
     number_of_atoms = df['number_of_atoms'][0]

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -26,24 +26,36 @@ def gruneisen_parameter(
     bulk_modulus_prime: float,
     gruneisen_constant: float
 ) -> float:
-    """calculates the gruneisen parameter
+    """Calculates the gruneisen parameter
 
     Args:
         bulk_modulus_prime: B_0', first derivative of the bulk modulus with respect to volume
         gruneisen_constant: x, Should be between 2/3 (high temperature) and 1 (low temperature)
 
     Returns:
-        float: gamma, the gruneisen parameter
+        gamma, the gruneisen parameter
     """    
     return (1+bulk_modulus_prime)/2 - gruneisen_constant
 
 def debye_temperature(
     volume: float,
-    eos_parameters: float,
+    eos_parameters: tuple[float],
     mass: float,
-    scaling_factor: float,
-    gru_param: float
+    gru_param: float,
+    scaling_factor: float = 0.617
 ) -> float:
+    """Calculates the Debye temperature within the Debye-Gruneisen model.
+
+    Args:
+        volume: Volume of the cell
+        eos_parameters: The parameters of the equation of state: (volume_0, energy_0, bulk_modulus, bulk_modulus_prime)
+        mass: Total mass of the cell
+        gru_param: gruneisen parameter
+        scaling_factor: Scaling factor defualts to 0.617 obtained by Moruzzi et al from nonmagnetic cubic metals
+
+    Returns:
+        Debye temperature
+    """    
     s = scaling_factor
     volume_0 = eos_parameters[0]
     energy_0 = eos_parameters[1]

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -191,30 +191,76 @@ def vibrational_energy(temperature: float, theta: float) -> float:
     debye_value = debye_function(theta/temperature)
     return 3 * BOLTZMANN * temperature * debye_value + 9/8 * BOLTZMANN * theta
 
-def vibrational_entropy(temperature: float, theta: float):
+def vibrational_entropy(temperature: float, theta: float) -> float:
+    """Evaluates the debye function at x = theta/temperature then
+    calculates the vibrational entropy in eV/K.
+    
+    Args:
+        temperature : Temperature in Kelvin
+        theta: Debye temperature in Kelvin
+    
+    Returns:
+        float: Vibrational entropy in eV/K
+    
+    """
     x = theta/temperature
     debye_value = debye_function(x)
     return 3*BOLTZMANN*(4/3*debye_value-np.log(1-np.exp(-x)))
 
-def vibrational_helmholtz_energy(temperature, theta):
+def vibrational_helmholtz_energy(temperature: float, theta:float) -> float:
+    """Evaluates the debye function at x = theta/temperature then
+    calculates the vibrational Helmholtz energy in eV.
+    
+    Args:
+        temperature : Temperature in Kelvin
+        theta: Debye temperature in Kelvin
+        
+    Returns:
+        float: Vibrational Helmholtz energy in eV
+    """
     x = theta/temperature
     debye_value = debye_function(x)
     return 9/8*BOLTZMANN*theta + BOLTZMANN*temperature*(3*np.log(1-np.exp(-x)) - debye_value)
 
-def vibrational_heat_capacity(temperature, theta):
+def vibrational_heat_capacity(temperature: float, theta: float) -> float:
+    """Evaluates the debye function and its derivative at x = theta/temperature then
+    calculates the vibrational heat capacity in eV/K.
+    
+    Args:
+        temperature : Temperature in Kelvin
+        theta: Debye temperature in Kelvin
+        
+    Returns:
+        float: Vibrational heat capacity in eV/K
+    """
     x = theta/temperature
-    return 3*BOLTZMANN*temperature*debye_function_derivative(x) + debye_function(x)
+    return 3*BOLTZMANN*temperature*debye_function_derivative(x) + debye_function(x) # could probably optimize with property of derivative
 
 def plot_debye(
-    temperatures,
-    volumes,
-    number_of_atoms,
-    y,
-    y_label,
-    selected_temperatures = None,
-    volume_decimals = 0,
-    temperature_decimals = 0
-    ):
+    temperatures: np.array,
+    volumes: np.array,
+    number_of_atoms: int,
+    y: np.array,
+    y_label: str,
+    selected_temperatures: np.array | None = None,
+    volume_decimals: int = 0,
+    temperature_decimals: int = 0
+) -> go.Figure:
+    """Plots the vibrational properties (S,F,C_V) as a function of temperature and volume
+    
+    Args:
+        temperatures: Array of temperatures
+        volumes: Array of volumes
+        number_of_atoms: Number of atoms in the cell
+        y: Array of vibrational properties (S,F,C_V)
+        y_label: Label for the y-axis ('S', 'F', 'C_V')
+        selected_temperatures: Array of selected temperatures curves to plot in the y vs volume plot. If None, 5 liniearly spaced temperatures are selected., 
+        volume_decimals: Number of decimals to display for the volume in the plot
+        temperature_decimals: Number of decimals to display for the temperature in the plot
+        
+    Returns:
+        go.Figure: Plotly figure object
+    """
     s_t_fig = go.Figure()
     for i, volume in enumerate(volumes):
         s_t_fig.add_trace(

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -182,7 +182,7 @@ def process_debye_gruneisen(
         magmom_tolerance = magmom_tolerance,
         total_magnetic_moment_tolerance = total_magnetic_moment_tolerance
     )
-    
+    print(df)
     # fit the equation of state
     volume = df['volume']
     energy = df['energy']

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -131,6 +131,7 @@ def vibrational_energy(temperature: float, theta: float, number_of_atoms) -> flo
     Args:
         temperature : Temperature in Kelvin
         theta: Debye temperature in Kelvin
+        number_of_atoms: Number of atoms in the cell
 
     Returns:
         float: Vibrational energy in eV
@@ -145,6 +146,7 @@ def vibrational_entropy(temperature: float, theta: float, number_of_atoms) -> fl
     Args:
         temperature : Temperature in Kelvin
         theta: Debye temperature in Kelvin
+        number_of_atoms: Number of atoms in the cell
     
     Returns:
         float: Vibrational entropy in eV/K
@@ -161,6 +163,7 @@ def vibrational_helmholtz_energy(temperature: float, theta:float, number_of_atom
     Args:
         temperature : Temperature in Kelvin
         theta: Debye temperature in Kelvin
+        number_of_atoms: Number of atoms in the cell
         
     Returns:
         float: Vibrational Helmholtz energy in eV
@@ -176,6 +179,7 @@ def vibrational_heat_capacity(temperature: float, theta: float, number_of_atoms)
     Args:
         temperature : Temperature in Kelvin
         theta: Debye temperature in Kelvin
+        number_of_atoms: Number of atoms in the cell
         
     Returns:
         float: Vibrational heat capacity in eV/K
@@ -223,13 +227,13 @@ def plot_debye(
     if selected_temperatures is None:
         indices = np.linspace(0, len(temperatures) - 1, 5, dtype=int)
         selected_temperatures = np.array([temperatures[j] for j in indices])
-    for i, temperature in enumerate(selected_temperatures):
+    for i in indices:
         s_v_fig.add_trace(
             go.Scatter(
                 x=volumes,
                 y=y[:, i],
                 mode='lines',
-                name=f'{temperature:.{temperature_decimals}f} K'))
+                name=f'{temperatures[i]:.{temperature_decimals}f} K'))
     plot_format(s_v_fig,"Volume (\u212B<sup>3</sup>)", f"{y_label}<sub>vib</sub> (eV/K/{number_of_atoms} atoms)")
     return s_t_fig, s_v_fig
 
@@ -287,9 +291,7 @@ def process_debye_gruneisen(
     gru_param = gruneisen_parameter(bulk_modulus_prime, gruneisen_x)
     
     if volumes is None:
-        volume_min = volume.min()
-        volume_max = volume.max() 
-        volumes = np.linspace(volume_min, volume_max, 10) 
+        volumes = volume
     
     total_mass = df['total_mass'][0]
     number_of_atoms = df['number_of_atoms'][0]

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -36,7 +36,8 @@ def debye_temperature(
     
     return s * A * volume_0**(1/6) * (bulk_modulus/mass)**(1/2) * (volume_0/volume)**gru_param
 
-def debye_function(x: float, order: int = 30):
+# TODO use a while loop to ensure convergence order=30 is plenty for x > -1.5𝜋
+def debye_function(x_array: np.array, order: int = 30):
     """series expansion of the debye function. valid for |𝑋|<2𝜋 and 𝑁≥1,
     comes from the expansion
     Gonzalez, I., Kondrashuk, I., Moll, V. H., & Vega, A. Analytic Expressions for Debye Functions and the Heat Capacity of a Solid. Mathematics, 10(10), 1745. https://doi.org/10.3390/math10101745
@@ -53,28 +54,30 @@ def debye_function(x: float, order: int = 30):
     Returns:
         _type_: _description_
     """
-    
     order = int(order)
-    
-
-    if x >= 0.7*np.pi:
-        summation = sum(1/k*(1 + 3/(k*x) + 6/(k**2*x**2) + 6/(k**3*x**3))*np.exp(-k*x) for k in range(1, order-1))
-        return np.pi**4/(5*x**3)-3*summation
-    elif -2*np.pi < x < 0.7*np.pi:
-        if order > 2:
-            bern_list = bernoulli(2*(order-2))
-            summation = sum(bern_list[2*k]/((2*k+3)*gamma(2*k+1)) * x**(2*k) for k in range(1, order-1))
-            return 1 - 3/8*x + 3 * summation
-        elif order == 2:
-            return 1 - 3/8*x
+    if order < 2:
+        raise ValueError("Order of the debye function series expansion must be greater than or equal to 2.")
+    result = np.zeros_like(x_array)
+    for i, x in enumerate(x_array):
+        if x >= 0.7*np.pi:
+            summation = sum(1/k*(1 + 3/(k*x) + 6/(k**2*x**2) + 6/(k**3*x**3))*np.exp(-k*x) for k in range(1, order-1))
+            result[i] = np.pi**4/(5*x**3)-3*summation
+        elif -2*np.pi < x < 0.7*np.pi:
+            if order > 2:
+                bern_list = bernoulli(2*(order-2))
+                summation = sum(bern_list[2*k]/((2*k+3)*gamma(2*k+1)) * x**(2*k) for k in range(1, order-1))
+                result[i] = 1 - 3/8*x + 3 * summation
+            elif order == 2:
+                result[i] = 1 - 3/8*x
+            else:
+                # value error
+                raise ValueError("Order of the debye function series expansion must be greater than or equal to 2.")
         else:
-            # value error
-            raise ValueError("Order of the debye function series expansion must be greater than or equal to 2.")
-    else:
-        raise ValueError("The debye function series expansions used are only valid for x > -2𝜋")
+            raise ValueError("The debye function series expansions used are only valid for x > -2𝜋")
+    return result
 
         
-
+# TODO use a while loop to ensure convergence. order=30 is plenty for x > -1.5𝜋
 def debye_function_derivative(x, order=30):
     """series expansion of the derivative of the debye function. valid for |𝑋|<2𝜋 and 𝑁≥1, comes from the expansion
     Gonzalez, I., Kondrashuk, I., Moll, V. H., & Vega, A. Analytic Expressions for Debye Functions and the Heat Capacity of a Solid. Mathematics, 10(10), 1745. https://doi.org/10.3390/math10101745
@@ -117,7 +120,7 @@ def vibrational_heat_capacity(temperature, theta):
     x = theta/temperature
     return 3*constants.k*temperature*debye_function_derivative(x) + debye_function(x)
 
-def debye_gruneisen(
+def process_debye_gruneisen(
     config_path,
     outcar_name: str = "OUTCAR.3static",
     oszicar_name: str = "OSZICAR.3static",
@@ -139,7 +142,9 @@ def debye_gruneisen(
     )
     
     # fit the equation of state
-    _, eos_parameters, _, _, _ = eos_fitting(df)
+    volume = df['volume']
+    energy = df['energy']
+    _, eos_parameters, _, _, _ = eos_fitting(volume, energy)
     volume_0, energy_0, bulk_modulus, bulk_modulus_prime, bulk_modulus_2prime = eos_parameters
     
     

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -36,7 +36,7 @@ def debye_temperature(
     
     return s * A * volume_0**(1/6) * (bulk_modulus/mass)**(1/2) * (volume_0/volume)**gru_param
 
-def debye_function(x: float, n: int = 3, order: int = 30):
+def debye_function(x: float, order: int = 30):
     """series expansion of the debye function. valid for |𝑋|<2𝜋 and 𝑁≥1,
     comes from the expansion
     Gonzalez, I., Kondrashuk, I., Moll, V. H., & Vega, A. Analytic Expressions for Debye Functions and the Heat Capacity of a Solid. Mathematics, 10(10), 1745. https://doi.org/10.3390/math10101745
@@ -57,21 +57,22 @@ def debye_function(x: float, n: int = 3, order: int = 30):
     order = int(order)
     
 
-    if x > 1.5*np.pi:
-        return
-        # return np.exp(-k*x)((x**n)/k + )
-    if x <= 1.5*np.pi:
+    if x >= 0.7*np.pi:
+        summation = sum(1/k*(1 + 3/(k*x) + 6/(k**2*x**2) + 6/(k**3*x**3))*np.exp(-k*x) for k in range(1, order-1))
+        return np.pi**4/(5*x**3)-3*summation
+    elif -2*np.pi < x < 0.7*np.pi:
         if order > 2:
             bern_list = bernoulli(2*(order-2))
-            summation = sum(bern_list[2*k]/((2*k+n)*gamma(2*k+1)) * x**(2*k) for k in range(1, order-1))
-            return 1 - n/(2*(n+1))*x + n * summation
+            summation = sum(bern_list[2*k]/((2*k+3)*gamma(2*k+1)) * x**(2*k) for k in range(1, order-1))
+            return 1 - 3/8*x + 3 * summation
         elif order == 2:
-            return 1 - n/(2*(n+1))*x
+            return 1 - 3/8*x
         elif order < 2:
             # value error
             raise ValueError("Order of the debye function series expansion must be greater than or equal to 2.")
-    elif x == 0:
-        return 1.0
+    else:
+        raise ValueError("The debye function series expansions used are only valid for x > -2𝜋")
+
         
 
 def debye_function_derivative(x, n=3, order=5):

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -261,6 +261,7 @@ def process_debye_gruneisen(
         config_path: Path to the config folder
         scaling_factor: s, Scaling factor for the Debye temperature
         gruneisen_x: x = 2/3 for high temperature case and x = 1 for low temperature case
+        mass_average: Type of averaging to use for the atomic masses. Can be 'arithmetic', 'geometric', or 'harmonic'
         volumes: Array of volumes to evaluate the Debye thermal properties at
         temperatures: Array of temperatures to evaluate the Debye thermal properties at
         outcar_name: Name of the OUTCAR file

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -269,7 +269,7 @@ def process_debye_gruneisen(
         eos_fitting: Equation of state fitting function from the eos_fit module
         
         Returns:
-            tuple[np.array, np.array, int, np.array, np.array, np.array]: temperatures, volumes, number of atoms, vibrational entropy, vibrational Helmholtz energy, vibrational heat capacity
+            tuple[np.array, np.array, int, np.array, np.array, np.array]: temperatures, volumes, number of atoms, and 2D arrays with rows (columns) corresponding to volumes (temperatures) vibrational entropy, vibrational Helmholtz energy, vibrational heat capacity
     """
     # extract the volume and energy from the ev_curve_series
     df = extract_configuration_data(

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -23,18 +23,18 @@ BOLTZMANN = constants.physical_constants['Boltzmann constant in eV/K'][0]
 # check docstring bulk modulus derivative with respect to ____
 def gruneisen_parameter(
     bulk_modulus_prime: float,
-    gruneisen_constant: float
+    gruneisen_x: float
 ) -> float:
     """Calculates the gruneisen parameter
 
     Args:
         bulk_modulus_prime: B_0', first derivative of the bulk modulus with respect to volume
-        gruneisen_constant: x, Should be between 2/3 (high temperature) and 1 (low temperature)
+        gruneisen_x: x, Should be between 2/3 (high temperature) and 1 (low temperature)
 
     Returns:
         gamma, the gruneisen parameter
     """    
-    return (1+bulk_modulus_prime)/2 - gruneisen_constant
+    return (1+bulk_modulus_prime)/2 - gruneisen_x
 
 def debye_temperature(
     volume: float,
@@ -237,7 +237,7 @@ def plot_debye(
 def process_debye_gruneisen(
     config_path: str,
     scaling_factor: float = 0.617,
-    gruneisen_constant: float = 1,
+    gruneisen_x: float = 1,
     volumes: np.array = None,
     temperatures: np.array = np.linspace(10, 1000, 100),
     outcar_name: str = "OUTCAR.3static",
@@ -253,7 +253,7 @@ def process_debye_gruneisen(
     Args:
         config_path: Path to the config folder
         scaling_factor: s, Scaling factor for the Debye temperature
-        gruneisen_constant: x, Gruneisen constant
+        gruneisen_x: x, Gruneisen constant
         volumes: Array of volumes to evaluate the Debye thermal properties at
         temperatures: Array of temperatures to evaluate the Debye thermal properties at
         outcar_name: Name of the OUTCAR file
@@ -284,8 +284,7 @@ def process_debye_gruneisen(
     volume_0, energy_0, bulk_modulus, bulk_modulus_prime, bulk_modulus_2prime = eos_parameters
     
     s = scaling_factor
-    gru_const = gruneisen_constant
-    gru_param = gruneisen_parameter(bulk_modulus_prime, gru_const)
+    gru_param = gruneisen_parameter(bulk_modulus_prime, gruneisen_x)
     
     if volumes is None:
         volume_min = volume.min()

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -31,7 +31,7 @@ def debye_temperature(volume, eos_parameters,
     return s * A * volume_0**(1/6) * (bulk_modulus/mass)**(1/2) * (volume_0/volume)**gru_param
 
 def debye_function(x, n=3, order=5):
-    """series expansion of the debye function
+    """series expansion of the debye function. valid for |𝑋|<2𝜋 and 𝑁≥1, comes from the expansion
     Gonzalez, I., Kondrashuk, I., Moll, V. H., & Vega, A. Analytic Expressions for Debye Functions and the Heat Capacity of a Solid. Mathematics, 10(10), 1745. https://doi.org/10.3390/math10101745
     """
     

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -13,20 +13,28 @@ from dfttk.qha_yphon import plot_format
 
 # A is the ____ constant of th Debye-Gruneisen model in units of
     # A = (8 * constants.pi**2)**(1/3)*constants.hbar/constants.k
+    
+
+# The definition of the Debye temperature is hbar/k_B * (6 * pi^2)^1/3 * N/V)
+# A = hbar/k_B * (6 * pi^2)^1/3
+# here A has units of K*s/(A*GPa*amu)^1/2 ??? check this ???
 A = 231.04
 BOLTZMANN = constants.physical_constants['Boltzmann constant in eV/K'][0]
 
 
-def gruneisen_parameter(bulk_modulus_prime, gruneisen_constant):
+def gruneisen_parameter(
+    bulk_modulus_prime: float,
+    gruneisen_constant: float
+) -> float:
     return (1+bulk_modulus_prime)/2 - gruneisen_constant
 
 def debye_temperature(
-    volume,
-    eos_parameters,
-    mass,
-    scaling_factor,
-    gru_param
-):
+    volume: float,
+    eos_parameters: float,
+    mass: float,
+    scaling_factor: float,
+    gru_param: float
+) -> float:
     s = scaling_factor
     volume_0 = eos_parameters[0]
     energy_0 = eos_parameters[1]
@@ -35,7 +43,7 @@ def debye_temperature(
     
     return s * A * volume_0**(1/6) * (bulk_modulus/mass)**(1/2) * (volume_0/volume)**gru_param
 
-# TODO use a while loop to ensure convergence order=30 is plenty for x > -1.5𝜋
+# TODO use a while loop to ensure convergence. order=30 is plenty for x > -1.5𝜋
 def debye_function(x_array: np.array, order: int = 30):
     """series expansion of the debye function. valid for |𝑋|<2𝜋 and 𝑁≥1,
     comes from the expansion

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -287,10 +287,10 @@ def plot_debye(
 
 
 def process_debye_gruneisen(
-    config_path,
+    config_path: str,
     scaling_factor: float = 0.617,
     gruneisen_constant: float = 1,
-    volumes: np.array = None,
+    volumes: np.array | None = None,
     temperatures: np.array = np.linspace(10, 1000, 100),
     outcar_name: str = "OUTCAR.3static",
     oszicar_name: str = "OSZICAR.3static",
@@ -299,7 +299,26 @@ def process_debye_gruneisen(
     magmom_tolerance: float = 1e-12,
     total_magnetic_moment_tolerance: float = 1e-12,
     eos_fitting = eos_fit.BM4
-):
+) -> tuple[np.array, np.array, int, np.array, np.array, np.array]:
+    """Applies the Debye-Gruneisen model to a given configuration for which E-V curve calculations have been performed.
+    
+    Args:
+        config_path: Path to the config folder
+        scaling_factor: s, Scaling factor for the Debye temperature
+        gruneisen_constant: x, Gruneisen constant
+        volumes: Array of volumes to evaluate the Debye thermal properties at
+        temperatures: Array of temperatures to evaluate the Debye thermal properties at
+        outcar_name: Name of the OUTCAR file
+        oszicar_name: Name of the OSZICAR file
+        contcar_name: Name of the CONTCAR file
+        collect_mag_data: Weather or not to collect magnetic data
+        magmom_tolerance: Magnetic moment tolerance for each atom
+        total_magnetic_moment_tolerance: Total magnetic moment tolerance
+        eos_fitting: Equation of state fitting function from the eos_fit module
+        
+        Returns:
+            tuple[np.array, np.array, int, np.array, np.array, np.array]: temperatures, volumes, number of atoms, vibrational entropy, vibrational Helmholtz energy, vibrational heat capacity
+    """
     # extract the volume and energy from the ev_curve_series
     df = extract_configuration_data(
         path = config_path,

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -1,0 +1,44 @@
+from scipy import constants
+from scipy.special import bernoulli
+from scipy.special import gamma
+from dfttk import eos_fit
+
+
+# A is the ____ constant of th Debye-Gruneisen model
+A = (8 * constants.pi**2)**(1/3)*constants.hbar/constants.k)
+
+def scaling_factor():
+    pass
+
+def gruneisen_constant():
+    pass
+
+def gruneisen_parameter(bulk_modulus_prime, gruneisen_constant):
+    return (1+bulk_modulus_prime)/2 - gruneisen_constant
+
+def debye_temperature(volume, eos_parameters,
+    mass,
+    scaling_factor,
+    gruneisen_constant):
+    s = scaling_factor
+    volume_0 = eos_parameters[0]
+    energy_0 = eos_parameters[1]
+    bulk_modulus = eos_parameters[2]
+    bulk_modulus_prime = eos_parameters[3]
+    
+    gru_param = gruneisen_parameter(bulk_modulus_prime, gruneisen_constant)
+    
+    return s * A * volume_0**(1/6) * (bulk_modulus/mass)**(1/2) * (volume_0/volume)**gru_param
+
+def debye_function(x, n=3, order=5):
+    """series expansion of the debye function
+    Gonzalez, I., Kondrashuk, I., Moll, V. H., & Vega, A. Analytic Expressions for Debye Functions and the Heat Capacity of a Solid. Mathematics, 10(10), 1745. https://doi.org/10.3390/math10101745
+    """
+    
+    for k in range(1, order-2):
+        summation = bernoulli(2*k)/((2*k+n)*gamma(2*k+1)) * x**(2*k)
+        
+    return 1 - n/(2(n+1)*x) + n*summation
+
+def debye_gruneisen_():
+    pass

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -4,13 +4,13 @@ from scipy import constants
 from scipy.special import bernoulli
 from scipy.special import gamma
 from dfttk import eos_fit
-from dfttk.data_extraction import extract_configuration_data
+from dfttk.aggregate_extraction import extract_configuration_data
 from dfttk.data_extraction import extract_mass
 
 
 
 # A is the ____ constant of th Debye-Gruneisen model
-A = (8 * constants.pi**2)**(1/3)*constants.hbar/constants.k)
+A = (8 * constants.pi**2)**(1/3)*constants.hbar/constants.k
 
 def scaling_factor():
     pass
@@ -36,14 +36,42 @@ def debye_temperature(
     
     return s * A * volume_0**(1/6) * (bulk_modulus/mass)**(1/2) * (volume_0/volume)**gru_param
 
-def debye_function(x, n=3, order=5):
-    """series expansion of the debye function. valid for |𝑋|<2𝜋 and 𝑁≥1, comes from the expansion
+def debye_function(x: float, n: int = 3, order: int = 30):
+    """series expansion of the debye function. valid for |𝑋|<2𝜋 and 𝑁≥1,
+    comes from the expansion
     Gonzalez, I., Kondrashuk, I., Moll, V. H., & Vega, A. Analytic Expressions for Debye Functions and the Heat Capacity of a Solid. Mathematics, 10(10), 1745. https://doi.org/10.3390/math10101745
     and Abramowitz, M. and Stegun, I.A. eds., 1968. Handbook of mathematical functions with formulas, graphs, and mathematical tables (Vol. 55). US Government printing office.
-    """
 
-    summation = sum(bernoulli(2*k)/((2*k+n)*gamma(2*k+1)) * x**(2*k) for k in range(1, order-2))
-    return 1 - n/(2(n+1))*x + n*summation
+    Args:
+        x: _description_
+        n: _description_. Defaults to 3.
+        order: the default is well within accuracy of floats and takes less than 0.0 seconds for n=3. Defaults to 30.
+
+    Raises:
+        ValueError: _description_
+
+    Returns:
+        _type_: _description_
+    """
+    
+    order = int(order)
+    
+
+    if x > 1.5*np.pi:
+        return np.exp(-k*x)((x**n)/k + )
+    if x <= 1.5*np.pi:
+        if order > 2:
+            bern_list = bernoulli(2*(order-2))
+            summation = sum(bern_list[2*k]/((2*k+n)*gamma(2*k+1)) * x**(2*k) for k in range(1, order-1))
+            return 1 - n/(2*(n+1))*x + n * summation
+        elif order == 2:
+            return 1 - n/(2*(n+1))*x
+        elif order < 2:
+            # value error
+            raise ValueError("Order of the debye function series expansion must be greater than or equal to 2.")
+    elif x == 0:
+        return 1.0
+        
 
 def debye_function_derivative(x, n=3, order=5):
     """series expansion of the derivative of the debye function. valid for |𝑋|<2𝜋 and 𝑁≥1, comes from the expansion
@@ -107,8 +135,10 @@ def debye_gruneisen(
     gru_const = gruneisen_constant()
     gru_param = gruneisen_parameter(bulk_modulus_prime, gru_const)
     
+    volume = np.array(1) # please finish this
+    temperature =  np.array(1) # please finish this
     theta = debye_temperature(volume, eos_parameters, mass, s, gru_param)
     x=theta/temperature
     debye_value = debye_function(x)
-    
+    return
     

--- a/dfttk/debye.py
+++ b/dfttk/debye.py
@@ -16,10 +16,10 @@ A = 231.04
 BOLTZMANN = constants.physical_constants['Boltzmann constant in eV/K'][0]
 
 def scaling_factor():
-    s = 0.75
+    return 0.75
 
-def gruneisen_constant():
-    pass
+def gruneisen_constant(temperature):
+    return 1.0
 
 def gruneisen_parameter(bulk_modulus_prime, gruneisen_constant):
     return (1+bulk_modulus_prime)/2 - gruneisen_constant


### PR DESCRIPTION
### Debye Module

`process_debye_gruneisen()` takes a path to a config, the scaling factor, and the gruneissen constant and applies the debye model and returns the vibrational entropy, Helmholtz energy, and heat capacity as well as the volumes, temperatures, and number of atoms used.

`plot_debye()` plots the data from `process_debye_gruneisen()`

![image](https://github.com/user-attachments/assets/b113dc1e-e36b-4a77-adde-a3da648f77d3)
![image](https://github.com/user-attachments/assets/bfa4b15c-a7d3-41c1-bca1-b2b793d458b0)


### Mass data extraction
Updates to both modules `data_extraction` and `aggraregate_extraction` to include information about the atomic mass and total mass at the end of the dataframe

energy_per_atom space_group  total_mass                atomic_masses  
0        -14.470477        Cmme     539.228  {'Fe': 55.847, 'Se': 78.96}  
1        -14.473422        Cmme     539.228  {'Fe': 55.847, 'Se': 78.96}  
2        -14.476012        Cmme     539.228  {'Fe': 55.847, 'Se': 78.96}  

### TODO before merge
add docstrings