### PR TITLE
Dev/nigelhew

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ It is recommended to first set up a virtual environment using Conda:
 
 Clone the main brach of the repository:
     
-    git clone https://github.com/PhasesResearchLab/dfttk2.git
+    git clone https://github.com/PhasesResearchLab/dfttk.git
 
 Or clone a specific branch:
     
-    git clone -b <branch_name> https://github.com/PhasesResearchLab/dfttk2.git
+    git clone -b <branch_name> https://github.com/PhasesResearchLab/dfttk.git
 
   Then move to `dfttk` directory and install in editable (`-e`) mode.
 

--- a/dfttk/data_extraction.py
+++ b/dfttk/data_extraction.py
@@ -110,11 +110,11 @@ def extract_atomic_masses(outcar_path: str) -> float:
         for line in lines:
             if "TITEL" in line:
                 atoms.append(line.split()[-2])
-            elif "POMASS" in line:
+            elif "POMASS" and "mass and valenz" in line:
                 mass = line.split()[2].replace(';', '')
                 masses.append(float(mass))
                 
-    # Clean atoms so that only the species is containted. e.g. 'Fe_pv' -> 'Fe'
+    # Clean atoms so that only the species is contained. e.g. 'Fe_pv' -> 'Fe'
     atoms = [atom.split('_')[0] for atom in atoms]
     
     atomic_masses = dict(zip(atoms, masses))

--- a/dfttk/quasi_harmonic.py
+++ b/dfttk/quasi_harmonic.py
@@ -25,6 +25,7 @@ def process_quasi_harmonic(
     eos: str = "BM4",
     plot: bool = True,
     plot_type: str = "default",
+    selected_temperatures_plot: list = None,
 ) -> pd.DataFrame:
     """Calculates the quasi-harmonic properties
 
@@ -37,6 +38,7 @@ def process_quasi_harmonic(
         P (int, optional): Pressure in GPa. Defaults to 0.
         plot (bool, optional): Defaults to True.
         plot_type (str, optional): Type of plots to include. Defaults to 'default'.
+        selected_temperatures_plot (list, optional): List of selected temperatures to plot. Defaults to None.
 
     Returns:
         pd.DataFrame: pandas dataframe containing the quasi-harmonic properties
@@ -252,29 +254,34 @@ def process_quasi_harmonic(
     quasi_harmonic_properties["Cp"] = Cp
 
     if plot == True:
-        plot_quasi_harmonic(quasi_harmonic_properties, plot_type)
+        plot_quasi_harmonic(quasi_harmonic_properties, plot_type, selected_temperatures_plot=selected_temperatures_plot)
 
     return quasi_harmonic_properties
 
 
 def plot_quasi_harmonic(
-    quasi_harmonic_properties: pd.DataFrame, plot_type: str = "default"
+    quasi_harmonic_properties: pd.DataFrame, plot_type: str = "default", selected_temperatures_plot: list = None
 ):
     """Plots the quasi-harmonic properties
 
     Args:
         quasi_harmonic_properties (pd.DataFrame): pandas dataframe containing the quasi-harmonic properties from the quasi_harmonic function
         plot_type (str, optional): Type of plots to include. Defaults to 'default'.
+        selected_temperatures_plot (list, optional): List of selected temperatures to plot. Defaults to None.
     """
 
     temperature_list = quasi_harmonic_properties["temperature"].values
-    spaces = len(temperature_list) - 1
-    step = int(spaces / 10)
+    if selected_temperatures_plot is None:
+        spaces = len(temperature_list) - 1
+        step = int(spaces / 10)
 
-    selected_temperatures = temperature_list[::step]
-    if selected_temperatures[-1] != temperature_list[-1]:
-        selected_temperatures = np.append(selected_temperatures, temperature_list[-1])
+        selected_temperatures = temperature_list[::step]
+        if selected_temperatures[-1] != temperature_list[-1]:
+            selected_temperatures = np.append(selected_temperatures, temperature_list[-1])
 
+    else:
+        selected_temperatures = selected_temperatures_plot
+        
     scale_atoms = quasi_harmonic_properties["number_of_atoms"].iloc[0]
 
     if plot_type == "default" or plot_type == "all":

--- a/dfttk/quasi_harmonic.py
+++ b/dfttk/quasi_harmonic.py
@@ -14,10 +14,12 @@ from dfttk.plotly_format import plot_format
 EV_PER_CUBIC_ANGSTROM_TO_GPA = 160.21766208  # 1 eV/Å^3  = 160.21766208 GPa
 
 
+# At the moment, the function can handle either phonon or debye. Should it handle both at the same time?
 def process_quasi_harmonic(
-    eos_parameters_df: pd.DataFrame,
-    harmonic_properties_fit: pd.DataFrame,
     volume_range: np.ndarray,
+    eos_parameters_df: pd.DataFrame,
+    harmonic_properties_fit: pd.DataFrame = None,
+    debye_properties: pd.DataFrame = None,
     thermal_electronic_properties_fit: pd.DataFrame = None,
     P: int = 0,
     eos: str = "BM4",
@@ -27,8 +29,11 @@ def process_quasi_harmonic(
     """Calculates the quasi-harmonic properties
 
     Args:
+        volume_range (np.ndarray): Volume range for the quasi-harmonic calculations
         eos_parameters_df (pd.DataFrame): pandas dataframe containing the EOS parameters from the eos_fit.fit_to_all function
-        harmonic_properties_fit (pd.DataFrame): pandas dataframe containing the fitted harmonic properties from the fit_harmonic function
+        harmonic_properties_fit (pd.DataFrame, optional): pandas dataframe containing the fitted harmonic properties from the fit_harmonic function
+        debye_properties (pd.DataFrame, optional): pandas dataframe containing the Debye properties. Defaults to None.
+        thermal_electronic_properties_fit (pd.DataFrame, optional): pandas dataframe containing the fitted thermal electronic properties. Defaults to None.
         P (int, optional): Pressure in GPa. Defaults to 0.
         plot (bool, optional): Defaults to True.
         plot_type (str, optional): Type of plots to include. Defaults to 'default'.
@@ -39,19 +44,32 @@ def process_quasi_harmonic(
 
     # Check that all properties have the same number of atoms
     num_atoms_eos = eos_parameters_df["number_of_atoms"].values[0]
-    num_atoms_vib = harmonic_properties_fit["number_of_atoms"].values[0]
-    if thermal_electronic_properties_fit is None:
-        if num_atoms_eos != num_atoms_vib:
-            raise ValueError(
-                "The number of atoms in eos_parameters_df and harmonic_properties_fit do not match"
-            )
 
-    if thermal_electronic_properties_fit is not None:
-        num_atoms_tec = thermal_electronic_properties_fit["number_of_atoms"].values[0]
-        if num_atoms_eos != num_atoms_vib or num_atoms_eos != num_atoms_tec:
-            raise ValueError(
-                "The number of atoms in eos_parameters_df and harmonic_properties_fit do not match"
-            )
+    # Phonons only
+    if harmonic_properties_fit is not None and debye_properties is None:
+        num_atoms_vib = harmonic_properties_fit["number_of_atoms"].values[0]
+        if num_atoms_eos != num_atoms_vib:
+            raise ValueError("The number of atoms do not match")
+        # Thermal electronic contribution
+        if thermal_electronic_properties_fit is not None:
+            num_atoms_tec = thermal_electronic_properties_fit["number_of_atoms"].values[
+                0
+            ]
+            if num_atoms_eos != num_atoms_tec:
+                raise ValueError("The number of atoms do not match")
+
+    # Debye model only
+    if debye_properties is not None and harmonic_properties_fit is None:
+        num_atoms_debye = debye_properties["number_of_atoms"].values[0]
+        if num_atoms_eos != num_atoms_debye:
+            raise ValueError("The number of atoms do not match")
+        # Thermal electronic contribution
+        if thermal_electronic_properties_fit is not None:
+            num_atoms_tec = thermal_electronic_properties_fit["number_of_atoms"].values[
+                0
+            ]
+            if num_atoms_eos != num_atoms_tec:
+                raise ValueError("The number of atoms do not match")
 
     # EOS parameters at 0 K
     if eos == "murnaghan" or eos == "vinet" or eos == "morse":
@@ -91,7 +109,12 @@ def process_quasi_harmonic(
     S0_list = []
 
     P = P / EV_PER_CUBIC_ANGSTROM_TO_GPA  # Convert GPa to eV/Å³
-    temperature_list = harmonic_properties_fit.index.tolist()
+
+    if harmonic_properties_fit is not None and debye_properties is None:
+        temperature_list = harmonic_properties_fit.index.tolist()
+
+    if debye_properties is not None and harmonic_properties_fit is None:
+        temperature_list = debye_properties["temperatures"].tolist()
 
     eos_fit_functions = {
         "mBM4": eos_fit.mBM4,
@@ -103,19 +126,44 @@ def process_quasi_harmonic(
     }
 
     for temperature in temperature_list:
+        if harmonic_properties_fit is not None and debye_properties is None:
+            f_vib_poly = harmonic_properties_fit.loc[temperature]["f_vib_poly"]
+            f_vib_fit = f_vib_poly(volume_range)
+            f_plus_pv = energy_eos + f_vib_fit + P * volume_range
 
-        f_vib_poly = harmonic_properties_fit.loc[temperature]["f_vib_poly"]
-        f_vib_fit = f_vib_poly(volume_range)
+            if thermal_electronic_properties_fit is not None:
+                f_el_poly = thermal_electronic_properties_fit.loc[temperature][
+                    "f_el_poly"
+                ]
+                f_el_fit = f_el_poly(volume_range)
+                f_plus_pv += f_el_fit
 
-        f_plus_pv = energy_eos + f_vib_fit + P * volume_range
-        
-        if thermal_electronic_properties_fit is not None:
-            f_el_poly = thermal_electronic_properties_fit.loc[temperature]["f_el_poly"]
-            f_el_fit = f_el_poly(volume_range)
-            f_plus_pv += f_el_fit
+            f_plus_pv_list.append(f_plus_pv)
+            volume_range_list.append(volume_range)
 
-        f_plus_pv_list.append(f_plus_pv)
-        volume_range_list.append(volume_range)
+        if debye_properties is not None and harmonic_properties_fit is None:
+            # Check if the volume range is the same as the one used for the Debye model
+            volume_range_debye = debye_properties[
+                debye_properties["temperatures"] == temperature
+            ]["volume"].values[0]
+            if not np.array_equal(volume_range, volume_range_debye):
+                raise ValueError(
+                    "The volume range used for the Debye model is different from the one used for the EOS"
+                )
+            f_vib = debye_properties[debye_properties["temperatures"] == temperature][
+                "f_vib"
+            ].values[0]
+            f_plus_pv = energy_eos + f_vib + P * volume_range
+
+            if thermal_electronic_properties_fit is not None:
+                f_el_poly = thermal_electronic_properties_fit.loc[temperature][
+                    "f_el_poly"
+                ]
+                f_el_fit = f_el_poly(volume_range)
+                f_plus_pv += f_el_fit
+
+            f_plus_pv_list.append(f_plus_pv)
+            volume_range_list.append(volume_range)
 
         try:
             eos_constants, eos_parameters, _, _, _ = eos_fit_functions[eos](
@@ -140,10 +188,18 @@ def process_quasi_harmonic(
         B_list.append(B)
         BP_list.append(BP)
 
-        s_vib_poly = harmonic_properties_fit.loc[temperature]["s_vib_poly"]
-        order = s_vib_poly.order
-        s_vib_fit = s_vib_poly(volume_range)
-        s = s_vib_fit
+        if harmonic_properties_fit is not None:
+            s_vib_poly = harmonic_properties_fit.loc[temperature]["s_vib_poly"]
+            order = s_vib_poly.order
+            s_vib_fit = s_vib_poly(volume_range)
+            s = s_vib_fit
+
+        if debye_properties is not None:
+            s_vib = debye_properties[debye_properties["temperatures"] == temperature][
+                "s_vib"
+            ].values[0]
+            s = s_vib
+            order = 2
 
         if thermal_electronic_properties_fit is not None:
             s_el_poly = thermal_electronic_properties_fit.loc[temperature]["s_el_poly"]
@@ -160,8 +216,7 @@ def process_quasi_harmonic(
     quasi_harmonic_properties = pd.DataFrame(
         data={
             "pressure": [P] * len(temperature_list),
-            "number_of_atoms": [harmonic_properties_fit["number_of_atoms"].iloc[0]]
-            * len(temperature_list),
+            "number_of_atoms": [num_atoms_eos] * len(temperature_list),
             "temperature": temperature_list,
             "volume_range": volume_range_list,
             "f_plus_pv": f_plus_pv_list,
@@ -214,7 +269,7 @@ def plot_quasi_harmonic(
 
     temperature_list = quasi_harmonic_properties["temperature"].values
     spaces = len(temperature_list) - 1
-    step = int(spaces / 9)
+    step = int(spaces / 10)
 
     selected_temperatures = temperature_list[::step]
     if selected_temperatures[-1] != temperature_list[-1]:
@@ -246,7 +301,11 @@ def plot_quasi_harmonic(
                     y=y,
                     mode="lines",
                     marker=dict(size=10),
-                    name=f"{temperature} K",
+                    name=(
+                        f"{int(temperature)} K"
+                        if temperature % 1 == 0
+                        else f"{temperature} K"
+                    ),
                 ),
             )
             fig.add_trace(

--- a/dfttk/quasi_harmonic.py
+++ b/dfttk/quasi_harmonic.py
@@ -14,7 +14,7 @@ from dfttk.plotly_format import plot_format
 EV_PER_CUBIC_ANGSTROM_TO_GPA = 160.21766208  # 1 eV/Å^3  = 160.21766208 GPa
 
 
-# At the moment, the function can handle either phonon or debye. Should it handle both at the same time?
+# TODO: Consider pulling out parallel code out of this function into separate functions
 def process_quasi_harmonic(
     volume_range: np.ndarray,
     eos_parameters_df: pd.DataFrame,

--- a/dfttk/thermal_electronic.py
+++ b/dfttk/thermal_electronic.py
@@ -12,6 +12,7 @@ import plotly.graph_objects as go
 import scipy.constants
 from scipy.special import expit
 from natsort import natsorted
+from scipy.interpolate import UnivariateSpline
 
 # Local application/library specific imports
 from pymatgen.io.vasp.outputs import Vasprun
@@ -111,6 +112,43 @@ def plot_total_electron_dos(electron_dos_data: pd.DataFrame):
         ytitle=f"DOS (states/eV/{electron_dos_data['number_of_atoms'].iloc[i]} atoms)",
     )
     fig.show()
+
+
+def fit_electron_dos(
+    energy: pd.Series | np.ndarray,
+    dos: pd.Series | np.ndarray,
+    energy_range: list[float, float],
+    resolution: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Fits the electron DOS with a spline
+
+    Args:
+        energy (pd.Series | np.ndarray): energy values from the electron DOS
+        dos (pd.Series | np.ndarray): electron DOS values
+        energy_range (list[float, float]): energy range to fit the electron DOS
+        resolution (float): energy resolution for the spline
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: fitted energy and DOS values
+    """
+
+    # Check if energy and dos are pandas Series and convert to NumPy arrays if necessary
+    if isinstance(energy, pd.Series):
+        energy = energy.values[0]
+    if isinstance(dos, pd.Series):
+        dos = dos.values[0]
+
+    # Filter the energy and dos values within the energy range
+    filtered_indices = (energy >= energy_range[0]) & (energy <= energy_range[1])
+    filtered_energy = energy[filtered_indices]
+    filtered_dos = dos[filtered_indices]
+
+    # Fit the filtered energy and dos values with a spline
+    spline = UnivariateSpline(filtered_energy, filtered_dos, s=0)
+    energy_fit = np.arange(energy_range[0], energy_range[1] + resolution, resolution)
+    dos_fit = spline(energy_fit)
+
+    return energy_fit, dos_fit
 
 
 def fermi_dirac_distribution(
@@ -274,6 +312,9 @@ def calculate_internal_energy(
     energy: pd.Series | np.ndarray,
     dos: pd.Series | np.ndarray,
     temperature_range: np.ndarray,
+    resolution: float = 0.001,
+    plot: bool = False,
+    plot_temperatures: np.ndarray = None,
 ) -> list:
     """Calculates the thermal electronic contribution to the internal energy
 
@@ -281,6 +322,9 @@ def calculate_internal_energy(
         energy (pd.Series | np.ndarray): energy values from the electron DOS
         dos (pd.Series | np.ndarray): electron DOS values
         temperature_range (np.ndarray): temperature range
+        resolution (float, optional): energy resolution for the spline. Defaults to 0.001.
+        plot (bool, optional): plots the integrand vs energy of the internal energy equation. Defaults to False.
+        plot_temperatures (np.ndarray, optional): temperatures to plot the integrand vs energy of the internal energy equation. Defaults to None.
 
     Returns:
         list: thermal electronic contribution to the internal energy
@@ -292,38 +336,106 @@ def calculate_internal_energy(
     if isinstance(dos, pd.Series):
         dos = dos.values[0]
 
+    energy_fit, dos_fit = fit_electron_dos(
+        energy, dos, [np.min(energy), np.max(energy)], resolution
+    )
+    integrand_1_list = []
+    filtered_energy_list = []
+    integrand_2_list = []
     E_el_list = []
     for temperature in temperature_range:
-        if temperature == 0:
-            E_el = 0
-            E_el_list.append(E_el)
-        
-        elif temperature > 0:
-            chemical_potential = calculate_chemical_potential(energy, dos, temperature)
-            fermi_dist = fermi_dirac_distribution(energy, chemical_potential, temperature)
+        chemical_potential = calculate_chemical_potential(
+            energy_fit, dos_fit, temperature
+        )
+        fermi_dist = fermi_dirac_distribution(
+            energy_fit, chemical_potential, temperature
+        )
 
-            integrand_1 = dos * fermi_dist * energy
-            integral_1 = np.trapz(integrand_1, energy)
+        integrand_1 = dos_fit * fermi_dist * energy_fit
+        integrand_1_list.append(integrand_1)
+        integral_1 = np.trapz(integrand_1, energy_fit)
 
-            # Only integrate over energy levels less than the chemical potential
-            mask = energy < chemical_potential
-            filtered_energy = energy[mask]
-            filtered_dos = dos[mask]
+        # Only integrate over energy levels less than the chemical potential
+        mask = energy_fit < chemical_potential
+        filtered_energy = energy_fit[mask]
+        filtered_energy_list.append(filtered_energy)
+        filtered_dos = dos_fit[mask]
 
-            integrand_2 = filtered_dos * filtered_energy
-            integral_2 = np.trapz(integrand_2, filtered_energy)
+        integrand_2 = filtered_dos * filtered_energy
+        integrand_2_list.append(integrand_2)
+        integral_2 = np.trapz(integrand_2, filtered_energy)
 
-            E_el = integral_1 - integral_2
-            E_el_list.append(E_el)
+        E_el = integral_1 - integral_2
+        E_el_list.append(E_el)
+
+    if plot:
+        for plot_temperature in plot_temperatures:
+            index = np.where(temperature_range == plot_temperature)[0][0]
+
+            plot_internal_energy_integral(
+                energy_fit,
+                integrand_1_list[index],
+                filtered_energy_list[index],
+                integrand_2_list[index],
+                plot_temperature,
+            )
 
     return E_el_list
+
+
+def plot_internal_energy_integral(
+    energy: np.ndarray,
+    integrand_1: np.ndarray,
+    filtered_energy: np.ndarray,
+    integrand_2: np.ndarray,
+    plot_temperature: float,
+):
+    """Plots the integrand vs energy of the internal energy equation
+
+    Args:
+        energy (np.ndarray): energy values from the electron DOS
+        integrand_1 (np.ndarray): integrand 1 from the internal energy equation
+        filtered_energy (np.ndarray): filtered energy values from the electron DOS
+        integrand_2 (np.ndarray): integrand 2 from the internal energy equation
+        plot_temperature (float): temperature
+    """
+
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=energy, y=integrand_1, mode="markers"))
+    fig.update_layout(
+        title=dict(
+            text=f"T = {plot_temperature} K",
+            font=dict(size=20, color="rgb(0,0,0)"),
+        ),
+        margin=dict(t=130),
+    )
+    plot_format(
+        fig, xtitle="E - E<sub>F</sub> (eV)", ytitle="E<sub>el</sub> integrand 1"
+    )
+    fig.show()
+
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=filtered_energy, y=integrand_2, mode="markers"))
+    fig.update_layout(
+        title=dict(
+            text=f"T = {plot_temperature} K",
+            font=dict(size=20, color="rgb(0,0,0)"),
+        ),
+        margin=dict(t=130),
+    )
+    plot_format(
+        fig, xtitle="E - E<sub>F</sub> (eV)", ytitle="E<sub>el</sub> integrand 2"
+    )
+    fig.show()
 
 
 def calculate_entropy(
     energy: pd.Series | np.ndarray,
     dos: pd.Series | np.ndarray,
     temperature_range: np.ndarray,
-    plot=False,
+    energy_range: list[float, float] = [-2, 2],
+    resolution: float = 0.0001,
+    plot: bool = False,
     plot_temperatures: np.ndarray = None,
 ) -> list:
     """Calculates the thermal electronic contribution to the entropy
@@ -332,6 +444,8 @@ def calculate_entropy(
         energy (pd.Series | np.ndarray): energy values from the electron DOS
         dos (pd.Series | np.ndarray): electron DOS values
         temperature_range (np.ndarray): temperature range
+        energy_range (list[float, float], optional): energy range to fit the electron DOS. Defaults to [-2, 2].
+        resolution (float, optional): energy resolution for the spline. Defaults to 0.0001.
         plot (bool, optional): plots the integrand vs energy of the entropy equation. Defaults to False.
         plot_temperatures (np.ndarray, optional): temperatures to plot the integrand vs energy of the entropy equation. Defaults to None.
 
@@ -345,42 +459,50 @@ def calculate_entropy(
     if isinstance(dos, pd.Series):
         dos = dos.values[0]
 
+    energy_fit, dos_fit = fit_electron_dos(energy, dos, energy_range, resolution)
+
     integrand_list = []
     S_el_list = []
     for temperature in temperature_range:
         if temperature == 0:
             S_el = 0
             S_el_list.append(S_el)
-            
-            integrand = np.zeros_like(energy)
+
+            integrand = np.zeros_like(energy_fit)
             integrand_list.append(integrand)
-            
+
         elif temperature > 0:
-            chemical_potential = calculate_chemical_potential(energy, dos, temperature)
-            fermi_dist = fermi_dirac_distribution(energy, chemical_potential, temperature)
+            chemical_potential = calculate_chemical_potential(
+                energy_fit, dos_fit, temperature
+            )
+            fermi_dist = fermi_dirac_distribution(
+                energy_fit, chemical_potential, temperature
+            )
 
             # The limit of f ln f + (1-f) ln (1-f) as f approaches 0 or 1 is 0
             mask = (fermi_dist == 0) | (fermi_dist == 1)
             integrand = np.zeros_like(fermi_dist)
-            integrand[~mask] = dos[~mask] * (
+            integrand[~mask] = dos_fit[~mask] * (
                 fermi_dist[~mask] * np.log(fermi_dist[~mask])
                 + (1 - fermi_dist[~mask]) * np.log(1 - fermi_dist[~mask])
             )
             integrand[mask] = 0
             integrand_list.append(integrand)
-            
-            S_el = -BOLTZMANN_CONSTANT * np.trapz(integrand, energy)
+
+            S_el = -BOLTZMANN_CONSTANT * np.trapz(integrand, energy_fit)
             S_el_list.append(S_el)
-    
+
     if plot:
         for plot_temperature in plot_temperatures:
             index = np.where(temperature_range == plot_temperature)[0][0]
-            plot_entropy_integral(energy, integrand_list[index], plot_temperature)
+            plot_entropy_integral(energy_fit, integrand_list[index], plot_temperature)
 
     return S_el_list
 
 
-def plot_entropy_integral(energy: np.ndarray, integrand: np.ndarray, plot_temperature: float):
+def plot_entropy_integral(
+    energy: np.ndarray, integrand: np.ndarray, plot_temperature: float
+):
     """Plots the integrand vs energy of the entropy equation
 
     Args:
@@ -409,6 +531,8 @@ def calculate_heat_capacity(
     energy: pd.Series | np.ndarray,
     dos: pd.Series | np.ndarray,
     temperature_range: np.ndarray,
+    energy_range: list[float, float] = [-2, 2],
+    resolution: float = 0.0001,
     plot=False,
     plot_temperatures: np.ndarray = None,
 ) -> list:
@@ -418,6 +542,8 @@ def calculate_heat_capacity(
         energy (pd.Series | np.ndarray): energy values from the electron DOS
         dos (pd.Series | np.ndarray): electron DOS values
         temperature_range (np.ndarray): temperature range
+        energy_range (list[float, float], optional): energy range to fit the electron DOS. Defaults to [-2, 2].
+        resolution (float, optional): energy resolution for the spline. Defaults to 0.0001.
         plot (bool, optional): plots the integrand vs energy of the heat capacity equation. Defaults to False.
         plot_temperatures (np.ndarray, optional): temperatures to plot the integrand vs energy of the heat capacity equation. Defaults to None.
 
@@ -431,44 +557,59 @@ def calculate_heat_capacity(
     if isinstance(dos, pd.Series):
         dos = dos.values[0]
 
+    energy_fit, dos_fit = fit_electron_dos(energy, dos, energy_range, resolution)
+
     integrand_list = []
     Cv_el_list = []
-    
+
     for temperature in temperature_range:
         if temperature == 0:
             Cv_el = 0
             Cv_el_list.append(Cv_el)
 
-            integrand = np.zeros_like(energy)
+            integrand = np.zeros_like(energy_fit)
             integrand_list.append(integrand)
-            
+
         elif temperature > 0:
-            chemical_potential = calculate_chemical_potential(energy, dos, temperature)
-            fermi_dist = fermi_dirac_distribution(energy, chemical_potential, temperature)
+            chemical_potential = calculate_chemical_potential(
+                energy_fit, dos_fit, temperature
+            )
+            fermi_dist = fermi_dirac_distribution(
+                energy_fit, chemical_potential, temperature
+            )
 
             # The limit of (1 / f - 1) * (f * (E - mu) / T) ** 2 as f approaches 0 or 1 is 0
             mask = (fermi_dist == 0) | (fermi_dist == 1)
             integrand = np.zeros_like(fermi_dist)
-            integrand[~mask] = dos[~mask] * (
+            integrand[~mask] = dos_fit[~mask] * (
                 (1 / fermi_dist[~mask] - 1)
-                * (fermi_dist[~mask] * (energy[~mask] - chemical_potential) / temperature) ** 2
+                * (
+                    fermi_dist[~mask]
+                    * (energy_fit[~mask] - chemical_potential)
+                    / temperature
+                )
+                ** 2
                 / BOLTZMANN_CONSTANT
             )
             integrand[mask] = 0
             integrand_list.append(integrand)
-            
-            Cv_el = np.trapz(integrand, energy)
+
+            Cv_el = np.trapz(integrand, energy_fit)
             Cv_el_list.append(Cv_el)
-            
+
     if plot:
         for plot_temperature in plot_temperatures:
             index = np.where(temperature_range == plot_temperature)[0][0]
-            plot_heat_capacity_integral(energy, integrand_list[index], plot_temperature)
+            plot_heat_capacity_integral(
+                energy_fit, integrand_list[index], plot_temperature
+            )
 
     return Cv_el_list
 
 
-def plot_heat_capacity_integral(energy: np.ndarray, integrand: np.ndarray, plot_temperature: float):
+def plot_heat_capacity_integral(
+    energy: np.ndarray, integrand: np.ndarray, plot_temperature: float
+):
     """plots the integrand vs energy of the heat capacity equation
 
     Args:
@@ -526,7 +667,7 @@ def thermal_electronic(
     temperature_range: np.ndarray,
     order: int = 2,
     plot: bool = True,
-    selected_temperatures_plot: np.ndarray = None
+    selected_temperatures_plot: np.ndarray = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Calculates the thermal electronic properties
 
@@ -536,7 +677,7 @@ def thermal_electronic(
         order (int, optional): order of polynomial to fit thermal electronic properties vs. volume for a fixed temperature. Defaults to 2.
         plot (bool, optional): plots the thermal electronic properties vs. temperature and vs. volume. Defaults to True.
         selected_temperatures_plot (np.ndarray, optional): selected temperatures to plot. Defaults to None.
-        
+
     Returns:
         tuple[pd.DataFrame, pd.DataFrame]: dataframes containing the thermal electronic properties and the fitted thermal electronic properties
     """
@@ -589,7 +730,9 @@ def thermal_electronic(
 
     if plot == True:
         plot_thermal_electronic(thermal_electronic_properties)
-        plot_thermal_electronic_properties_fit(thermal_electronic_properties_fit, selected_temperatures_plot)
+        plot_thermal_electronic_properties_fit(
+            thermal_electronic_properties_fit, selected_temperatures_plot
+        )
 
     return thermal_electronic_properties, thermal_electronic_properties_fit
 
@@ -709,7 +852,7 @@ def fit_thermal_electronic(
 
 def plot_thermal_electronic_properties_fit(
     thermal_electronic_properties_fit: pd.DataFrame,
-    selected_temperatures_plot: np.ndarray = None
+    selected_temperatures_plot: np.ndarray = None,
 ):
     """Plots the fitted thermal electronic properties vs. volume for various fixed temperatures
 
@@ -723,12 +866,11 @@ def plot_thermal_electronic_properties_fit(
     if selected_temperatures_plot is None:
         indices = np.linspace(0, len(temperature_list) - 1, 5, dtype=int)
         selected_temperatures_plot = np.array([temperature_list[j] for j in indices])
-    
+
     y_values = [
         ("f_el", "f_el_fit"),
         ("s_el", "s_el_fit"),
         ("cv_el", "cv_el_fit"),
-
     ]
     for y_value, y_value_fit in y_values:
         fig = go.Figure()
@@ -748,7 +890,7 @@ def plot_thermal_electronic_properties_fit(
             f"rgba({int(color[1:3], 16)}, {int(color[3:5], 16)}, {int(color[5:7], 16)}, {1})"
             for color in colors
         ]
-        
+
         i = 0
         for i, temperature in enumerate(selected_temperatures_plot):
             x = thermal_electronic_properties_fit.loc[temperature]["volume"]
@@ -757,7 +899,7 @@ def plot_thermal_electronic_properties_fit(
             y_fit = thermal_electronic_properties_fit.loc[temperature][y_value_fit]
 
             color = colors[i % len(colors)]
-            
+
             fig.add_trace(
                 go.Scatter(
                     x=x,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "pymongo>=4.4",
 ]
 
-keywords = ["VASP", "automation", "thermodynamics", "dfttk2", "DFT", "materials", "science", "MongoDB"]
+keywords = ["VASP", "automation", "thermodynamics", "dfttk", "DFT", "materials", "science", "MongoDB"]
 
 [project.urls]
-"Homepage" = "https://github.com/PhasesResearchLab/dfttk2"
+"Homepage" = "https://github.com/PhasesResearchLab/dfttk"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "dfttk2"
+name = "dfttk"
 version = "0.0.0"
 authors = [
   { name="Luke A. Myers", email="lam7027@psu.edu" },


### PR DESCRIPTION
mongo.py and quasi_harmonic.py
- mongo.py now incorporates the debye model. See the MongoDB compass for an example of Al.

quasi_harmonic.py
- quasi_harmonic.py now incorporates the debye model
- Added the option to plot selected temperatures in the F + PV vs V plot
- fixed a bug in def process_quasi_harmonic. Before it would modify debye_properties if thermal_electronic_properties_fit was supplied.

thermal_electronic.py
- Improved plotting for def calculate_entropy and def calculate_heat_capacity. Most users won't need to see this, but it is useful for evaluating the quality of the integrals. 
- Added def fit_electron_dos to fit the electron DOS to a spline. Seems to work quite well.

README.md and pyproject.toml
- dfttk2 -> dfttk

data_extraction.py
- def extract_atomic_masses
  - Changed the line `elif "POMASS" in line:` to `elif "POMASS" in line and "mass and valenz in line":` as it was reading other lines with "POMASS" that are not supposed to be read.