### PR TITLE
try and except blocks for config in in `fit_to_all_eos()`

### DIFF
--- a/dfttk/eos_fit.py
+++ b/dfttk/eos_fit.py
@@ -1202,56 +1202,57 @@ def fit_to_all_eos(df: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
         volumes = config_df["volume"].values
         energies = config_df["energy"].values
         number_of_atoms = config_df["number_of_atoms"].values[0]
-
-        for eos_function in eos_functions:
-            eos_constants, eos_parameters, volume_range, energy_eos, pressure_eos = (
-                eos_function(volumes, energies)
-            )
-            eos_name = eos_function.__name__
-
-            dataframes.append(
-                pd.DataFrame(
-                    [
-                        [
-                            config,
-                            eos_name,
-                            number_of_atoms,
-                            eos_constants[0],
-                            eos_constants[1],
-                            eos_constants[2],
-                            eos_constants[3],
-                            eos_constants[4],
-                            eos_parameters[0],
-                            eos_parameters[1],
-                            eos_parameters[2],
-                            eos_parameters[3],
-                            eos_parameters[4],
-                            volume_range,
-                            energy_eos,
-                            pressure_eos,
-                        ]
-                    ],
-                    columns=[
-                        "config",
-                        "eos",
-                        "number_of_atoms",
-                        "a",
-                        "b",
-                        "c",
-                        "d",
-                        "e",
-                        "V0",
-                        "E0",
-                        "B",
-                        "BP",
-                        "B2P",
-                        "volumes",
-                        "energies",
-                        "pressures",
-                    ],
+        try:
+            for eos_function in eos_functions:
+                eos_constants, eos_parameters, volume_range, energy_eos, pressure_eos = (
+                    eos_function(volumes, energies)
                 )
-            )
+                eos_name = eos_function.__name__
 
+                dataframes.append(
+                    pd.DataFrame(
+                        [
+                            [
+                                config,
+                                eos_name,
+                                number_of_atoms,
+                                eos_constants[0],
+                                eos_constants[1],
+                                eos_constants[2],
+                                eos_constants[3],
+                                eos_constants[4],
+                                eos_parameters[0],
+                                eos_parameters[1],
+                                eos_parameters[2],
+                                eos_parameters[3],
+                                eos_parameters[4],
+                                volume_range,
+                                energy_eos,
+                                pressure_eos,
+                            ]
+                        ],
+                        columns=[
+                            "config",
+                            "eos",
+                            "number_of_atoms",
+                            "a",
+                            "b",
+                            "c",
+                            "d",
+                            "e",
+                            "V0",
+                            "E0",
+                            "B",
+                            "BP",
+                            "B2P",
+                            "volumes",
+                            "energies",
+                            "pressures",
+                        ],
+                    )
+                )
+        except Exception as e:
+            print(f"Error fitting config {config}: {e}")
     eos_df = pd.concat(dataframes, ignore_index=True)
     eos_values_df = eos_df.drop(
         columns=["a", "b", "c", "d", "e", "V0", "E0", "B", "BP", "B2P"]
@@ -1572,7 +1573,6 @@ def plot_ev(
 
                 else:
                     raise ValueError("highlight_minimum must be True or False")
-
     axis_params = dict(
         showline=True,
         linecolor="black",


### PR DESCRIPTION
added a try and except block in `fit_to_all_eos()` such that it will still fit other configs even if one config doesn't work.

I was having trouble with the fitting not working for bad data, wich caused `plot_ev()` to error and not plot any of the configs.
```
RuntimeWarning:

The iteration is not making good progress, as measured by the 
  improvement from the last ten iterations.
```

With the fix it will plot the configs that work and print a warning that looks like this: `Error fitting config 7: Optimal parameters not found: Number of calls to function has reached maxfev = 1000.`