### PR TITLE
MAINT: Rename process_debye_gruneisen to process in DebyeGruneisen class

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,11 +2,7 @@ name: tests
 
 on:
   push:
-    branches:
-      - main
   pull_request:
-    branches:
-      - main
 
 jobs:
   test:
@@ -41,4 +37,4 @@ jobs:
         pytest tests/test_eos.py
         pytest tests/test_debye.py
         pytest tests/test_magnetism.py
-    
+

--- a/dfttk/config.py
+++ b/dfttk/config.py
@@ -352,24 +352,10 @@ workflows.NELM_reached(os.getcwd())
         gruneisen_x: float = 2/3,
         temperatures: np.array = np.linspace(0, 1000, 101),
     ):
-        '''
-        self.debye = DebyeData()
 
-        self.debye.get_debye_gruneisen_data(
-            self.ev_curve.number_of_atoms,
-            self.ev_curve.volumes,
-            self.ev_curve.average_mass,
-            self.ev_curve.eos_parameters["V0"],
-            self.ev_curve.eos_parameters["B"],
-            self.ev_curve.eos_parameters["BP"],
-            scaling_factor,
-            gruneisen_x,
-            temperatures,
-        )
-        '''
         volumes = np.linspace(0.98 * min(self.ev_curve.volumes), 1.02 * max(self.ev_curve.volumes), 1000)
         self.debye = DebyeGruneisen()
-        self.debye.process_debye_gruneisen(
+        self.debye.process(
             number_of_atoms=self.ev_curve.number_of_atoms,
             volumes=volumes,
             temperatures=temperatures,

--- a/dfttk/debye/debye_gruneisen.py
+++ b/dfttk/debye/debye_gruneisen.py
@@ -170,7 +170,7 @@ class DebyeGruneisen:
                 heat_capacities[i] = 3 * self.number_of_atoms * BOLTZMANN_CONSTANT * debye_integrals[i]
         return heat_capacities
 
-    def process_debye_gruneisen(
+    def process(
         self,
         number_of_atoms: int,
         volumes: np.ndarray,

--- a/tests/test_debye.py
+++ b/tests/test_debye.py
@@ -69,7 +69,7 @@ expected_heat_capacities = np.array([
 
 def test_DebyeGruneisen():
     debye = DebyeGruneisen()
-    debye.process_debye_gruneisen(
+    debye.process(
         number_of_atoms,
         volumes,
         temperatures,


### PR DESCRIPTION
Renames the Debye–Grüneisen processing method, updates its usages in config and tests, and broadens CI to run on all branches.

- Rename DebyeGruneisen.process_debye_gruneisen to DebyeGruneisen.process
- Update config.py to call the new method and remove commented-out legacy code
- Adjust tests and CI workflow to reflect the rename and run on every branch